### PR TITLE
Hide npm funding messages during build

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+fund=false


### PR DESCRIPTION
This small PR adds an .npmrc configuration file to hide the npm funding messages that appear during the build process.

## Changes
- Added .npmrc with fund=false configuration
- This removes the '232 packages are looking for funding run npm fund for details' message during build