### PR TITLE
Fix redirect loops and duplicate blog posts

### DIFF
--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -1,19 +1,31 @@
 ---
-import { getCollection } from 'astro:content';
+import { type CollectionEntry, getCollection } from 'astro:content';
+import BlogPostLayout from '../../layouts/BlogPostLayout.astro';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
-  
+
   return posts.map(post => {
     return {
       params: { slug: post.slug },
-      props: { post }
+      props: post
     };
   });
 }
 
-const { slug } = Astro.params;
+type Props = CollectionEntry<'blog'>;
 
-// Server-side redirect to the canonical URL
-return Astro.redirect(`/blog/${slug}/`, 301);
+const post = Astro.props;
+const { Content } = await post.render();
 ---
+
+<BlogPostLayout
+  title={post.data.title}
+  description={post.data.description}
+  pubDate={post.data.pubDate}
+  updatedDate={post.data.updatedDate}
+  heroImage={post.data.heroImage}
+  slug={post.slug}
+>
+  <Content />
+</BlogPostLayout>

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,8 @@
   "trailingSlash": false,
   "redirects": [
     { "source": "/posts", "destination": "/", "permanent": true },
-    { "source": "/posts/(.*)", "destination": "/blog/$1", "permanent": true },
+    { "source": "/posts/(.*)/", "destination": "/blog/$1/", "permanent": true },
+    { "source": "/posts/(.*)$", "destination": "/blog/$1/", "permanent": true },
     { "source": "/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug", "destination": "/blog/:slug/", "permanent": true },
     { "source": "/blog/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug", "destination": "/blog/:slug/", "permanent": true },
     { "source": "/blog/:slug([^\\/]+)$", "destination": "/blog/:slug/", "permanent": true },


### PR DESCRIPTION
## Summary
- Fixed redirect loops between /blog/ and /posts/ paths
- Modified posts/[...slug].astro to render content directly instead of redirecting
- Updated vercel.json redirect rules with proper regex patterns
- Fixed ESLint error in env.d.ts file

## Test plan
- Verify blog posts are accessible at both /blog/post-name/ and /posts/post-name/ paths
- Confirm no infinite redirects occur
- Validate that blog posts render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)