### PR TITLE
Fix blog URL handling to support both /blog/ and /posts/ paths

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,72 +1,31 @@
 ---
 import { type CollectionEntry, getCollection } from 'astro:content';
-import BaseLayout from '../../layouts/BaseLayout.astro';
-import FormattedDate from '../../components/FormattedDate.astro';
-import { render } from 'astro:content';
+import BlogPostLayout from '../../layouts/BlogPostLayout.astro';
 
 export async function getStaticPaths() {
-	const posts = await getCollection('blog');
-	return posts.map((post) => ({
-		params: { slug: post.slug },
-		props: post,
-	}));
+  const posts = await getCollection('blog');
+
+  return posts.map(post => {
+    return {
+      params: { slug: post.slug },
+      props: post
+    };
+  });
 }
+
 type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
-const { Content } = await render(post);
+const { Content } = await post.render();
 ---
 
-<BaseLayout title={post.data.title} description={post.data.description}>
-	<article class="post">
-		<h1 class="post-title">{post.data.title}</h1>
-
-		<div class="post-meta">
-			<span>
-				Posted on <FormattedDate date={post.data.pubDate} />
-				{post.data.updatedDate && (
-					<span class="last-updated-on">
-						· Updated on <FormattedDate date={post.data.updatedDate} />
-					</span>
-				)}
-			</span>
-		</div>
-
-		{post.data.heroImage && (
-			<div class="hero-image">
-				<img src={post.data.heroImage} alt="" />
-			</div>
-		)}
-
-		<div class="post-content">
-			<Content />
-		</div>
-	</article>
-</BaseLayout>
-
-<style>
-	.post-title {
-		margin-bottom: 0.5rem;
-	}
-
-	.post-meta {
-		color: #6c757d;
-		font-size: 0.9rem;
-		margin-bottom: 2rem;
-	}
-
-	.hero-image {
-		margin: 2rem 0;
-	}
-
-	.hero-image img {
-		width: 100%;
-		height: auto;
-		border-radius: 8px;
-		box-shadow: var(--box-shadow);
-	}
-
-	.post-content {
-		line-height: 1.8;
-	}
-</style>
+<BlogPostLayout
+  title={post.data.title}
+  description={post.data.description}
+  pubDate={post.data.pubDate}
+  updatedDate={post.data.updatedDate}
+  heroImage={post.data.heroImage}
+  slug={post.slug}
+>
+  <Content />
+</BlogPostLayout>

--- a/vercel.json
+++ b/vercel.json
@@ -7,8 +7,6 @@
   "trailingSlash": false,
   "redirects": [
     { "source": "/posts", "destination": "/", "permanent": true },
-    { "source": "/posts/(.*)/", "destination": "/blog/$1/", "permanent": true },
-    { "source": "/posts/(.*)$", "destination": "/blog/$1/", "permanent": true },
     { "source": "/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug", "destination": "/blog/:slug/", "permanent": true },
     { "source": "/blog/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug", "destination": "/blog/:slug/", "permanent": true },
     { "source": "/blog/:slug([^\\/]+)$", "destination": "/blog/:slug/", "permanent": true },


### PR DESCRIPTION
## Summary
- Updated blog/[...slug].astro to use BlogPostLayout (same as posts/[...slug].astro)
- Removed redirects from /posts/ to /blog/ in vercel.json
- This allows content to be accessible from both paths directly without redirect loops

## Test plan
- Verify blog posts are accessible at both /blog/post-name/ and /posts/post-name/ paths
- Confirm no redirects occur when accessing either path
- Validate that blog posts render correctly with the proper layout on both paths

🤖 Generated with [Claude Code](https://claude.ai/code)