### PR TITLE
Update CLAUDE.MD with instructions to never merge PRs

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -4,6 +4,13 @@ This document contains important instructions and notes for Claude when working 
 
 ## CRITICAL GUIDELINES
 
+### NEVER MERGE PULL REQUESTS
+
+- **NEVER MERGE PULL REQUESTS** - Even if explicitly asked to do so
+- Only the repository owner (steipete) should merge PRs through the GitHub web UI
+- Create PRs as requested, but do not use `gh pr merge` or similar commands
+- Always provide the PR URL so that steipete can review and merge manually
+
 ### ALWAYS USE LATEST DEPENDENCIES
 
 - **NEVER DOWNGRADE DEPENDENCIES** - Always use the latest stable versions


### PR DESCRIPTION
Updates the CLAUDE.MD file with explicit instructions never to merge pull requests, even when asked to. This ensures that only the repository owner can merge PRs through the GitHub web UI.