### PR TITLE
Brighten text in code blocks and lists for dark mode

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -330,11 +330,11 @@ pre code {
   .token.prolog,
   .token.doctype,
   .token.cdata {
-    color: #8b949e;
+    color: #a9b6c4;
   }
 
   .token.punctuation {
-    color: #c9d1d9;
+    color: #e0e7f0;
   }
 
   .token.namespace {
@@ -348,7 +348,7 @@ pre code {
   .token.constant,
   .token.symbol,
   .token.deleted {
-    color: #ff7b72;
+    color: #ff9c97;
   }
 
   .token.selector,
@@ -357,7 +357,7 @@ pre code {
   .token.char,
   .token.builtin,
   .token.inserted {
-    color: #7ee787;
+    color: #a3ffad;
   }
 
   .token.operator,
@@ -365,24 +365,24 @@ pre code {
   .token.url,
   .language-css .token.string,
   .style .token.string {
-    color: #79c0ff;
+    color: #9dd0ff;
   }
 
   .token.atrule,
   .token.attr-value,
   .token.keyword {
-    color: #a5d6ff;
+    color: #c4e1ff;
   }
 
   .token.function,
   .token.class-name {
-    color: #d2a8ff;
+    color: #e2c4ff;
   }
 
   .token.regex,
   .token.important,
   .token.variable {
-    color: #ffa657;
+    color: #ffb983;
   }
 }
 

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -5,7 +5,7 @@
     @apply text-base leading-7;
 
     p {
-      @apply text-gray-700 dark:text-gray-300 my-5;
+      @apply text-gray-700 dark:text-gray-200 my-5;
     }
 
     h1 {
@@ -41,15 +41,15 @@
     }
 
     ul {
-      @apply my-5 ml-6 list-disc [&>li]:mt-2;
+      @apply my-5 ml-6 list-disc [&>li]:mt-2 dark:text-gray-50;
     }
 
     ol {
-      @apply my-5 ml-6 list-decimal [&>li]:mt-2;
+      @apply my-5 ml-6 list-decimal [&>li]:mt-2 dark:text-gray-50;
     }
 
     li {
-      @apply pl-2 [&>p]:my-0;
+      @apply pl-2 [&>p]:my-0 dark:text-gray-50;
     }
 
     ul ul,


### PR DESCRIPTION
## Summary
- Significantly improves readability of all text elements in dark mode
- Makes list elements brighter with text-gray-50 class
- Brightens paragraph text from text-gray-300 to text-gray-200
- Enhances syntax highlighting with more vibrant colors
- Improves overall contrast for code elements

## Test plan
- Verify lists and code blocks are easily readable in dark mode
- Check that text has proper contrast against the background
- Confirm syntax highlighting is clearly visible with enhanced colors

🤖 Generated with [Claude Code](https://claude.ai/code)