### PR TITLE
Make code blocks and syntax highlighting brighter in dark mode

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -318,6 +318,7 @@ pre code {
   pre code {
     color: #ffffff;
     text-wrap: pretty;
+    font-weight: 500;
   }
   
   code {
@@ -330,15 +331,15 @@ pre code {
   .token.prolog,
   .token.doctype,
   .token.cdata {
-    color: #a9b6c4;
+    color: #bbc7d3;
   }
 
   .token.punctuation {
-    color: #e0e7f0;
+    color: #ffffff;
   }
 
   .token.namespace {
-    opacity: 0.7;
+    opacity: 0.8;
   }
 
   .token.property,
@@ -348,7 +349,7 @@ pre code {
   .token.constant,
   .token.symbol,
   .token.deleted {
-    color: #ff9c97;
+    color: #ffb0ac;
   }
 
   .token.selector,
@@ -357,7 +358,7 @@ pre code {
   .token.char,
   .token.builtin,
   .token.inserted {
-    color: #a3ffad;
+    color: #b9ffbf;
   }
 
   .token.operator,
@@ -365,24 +366,24 @@ pre code {
   .token.url,
   .language-css .token.string,
   .style .token.string {
-    color: #9dd0ff;
+    color: #b3dbff;
   }
 
   .token.atrule,
   .token.attr-value,
   .token.keyword {
-    color: #c4e1ff;
+    color: #d9ebff;
   }
 
   .token.function,
   .token.class-name {
-    color: #e2c4ff;
+    color: #ecd9ff;
   }
 
   .token.regex,
   .token.important,
   .token.variable {
-    color: #ffb983;
+    color: #ffd2a6;
   }
 }
 


### PR DESCRIPTION
## Summary
- Increased visibility of code blocks in dark mode by adding font-weight: 500
- Brightened all syntax highlighting token colors for better readability in dark mode
- Made comments, punctuation, and all syntax elements more vibrant and easier to distinguish

## Test plan
- Build the site with \
> steipete-astro@0.0.1 build
> astro build

15:45:13 [types] Generated 146ms
15:45:13 [build] output: "static"
15:45:13 [build] directory: /Users/steipete/Projects/steipete-astro/dist/
15:45:13 [build] Collecting build info...
15:45:13 [build] ✓ Completed in 163ms.
15:45:13 [build] Building static entrypoints...
15:45:15 [vite] ✓ built in 2.14s
15:45:15 [build] ✓ Completed in 2.15s.

 building client (vite) 
15:45:15 [vite] transforming...
15:45:15 [vite] ✓ 38 modules transformed.
15:45:15 [vite] rendering chunks...
15:45:15 [vite] computing gzip size...
15:45:15 [vite] dist/_astro/mobile-menu.DeG6PlOq.js    2.49 kB │ gzip:  1.25 kB
15:45:15 [vite] dist/_astro/index.CVf8TyFT.js          6.72 kB │ gzip:  2.68 kB
15:45:15 [vite] dist/_astro/client.Zy1ddoEA.js       136.05 kB │ gzip: 43.86 kB
15:45:15 [vite] ✓ built in 189ms

 generating static routes 
15:45:15 ▶ src/pages/about.astro
15:45:15   └─ /about/index.html (+6ms)
15:45:15 ▶ src/pages/blog/[page].astro
15:45:15   ├─ /blog/2/index.html (+1ms)
15:45:15   ├─ /blog/3/index.html (+0ms)
15:45:15   ├─ /blog/4/index.html (+0ms)
15:45:15   ├─ /blog/5/index.html (+0ms)
15:45:15   ├─ /blog/6/index.html (+0ms)
15:45:15   └─ /blog/7/index.html (+0ms)
15:45:15 ▶ src/pages/blog/index.astro
15:45:15   └─ /blog/index.html (+0ms)
15:45:15 ▶ src/pages/blog/[...slug].astro
15:45:15   ├─ /blog/2020-05-14-lets-try-this-again/index.html (+1ms)
15:45:15   ├─ /blog/2020-05-19-how-to-macos-core-dump/index.html (+0ms)
15:45:15   ├─ /blog/2020-05-19-kernel-panic-surprise-boot-args/index.html (+0ms)
15:45:15   ├─ /blog/2020-05-19-the-lg-ultrafine5k-kerneltask-and-me/index.html (+0ms)
15:45:15   ├─ /blog/2020-05-21-network-kernel-core-dump/index.html (+0ms)
15:45:15   ├─ /blog/2020-05-26-jailbreaking-for-ios-developers/index.html (+0ms)
15:45:15   ├─ /blog/2020-05-30-mac-catalyst-crash-hunt/index.html (+0ms)
15:45:15   ├─ /blog/2020-05-31-interposekit/index.html (+0ms)
15:45:15   ├─ /blog/2020-06-01-updating-a-hackintosh/index.html (+0ms)
15:45:15   ├─ /blog/2020-06-04-couldnt-irgen-expression/index.html (+0ms)
15:45:15   ├─ /blog/2020-06-05-zld-a-faster-linker/index.html (+0ms)
15:45:15   ├─ /blog/2020-06-10-calling-super-at-runtime/index.html (+0ms)
15:45:15   ├─ /blog/2020-06-12-building-with-swift-trunk/index.html (+0ms)
15:45:15   ├─ /blog/2020-08-22-logging-in-swift/index.html (+0ms)
15:45:15   ├─ /blog/2020-09-21-disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+0ms)
15:45:15   ├─ /blog/2020-09-22-forbidden-controls-in-catalyst-mac-idiom/index.html (+0ms)
15:45:15   ├─ /blog/2020-10-21-curating-your-twitter-timeline/index.html (+0ms)
15:45:15   ├─ /blog/2020-10-21-growing-your-twitter-followers/index.html (+0ms)
15:45:15   ├─ /blog/a-new-beginning/index.html (+0ms)
15:45:15   ├─ /blog/a-story-about-swizzling-the-right-way-and-touch-forwarding/index.html (+0ms)
15:45:15   ├─ /blog/adding-keyboard-shortcuts-to-uialertview/index.html (+0ms)
15:45:15   ├─ /blog/apple-silicon-m1-a-developer-perspective/index.html (+0ms)
15:45:15   ├─ /blog/apple-silicon-mac-mini-for-ci/index.html (+0ms)
15:45:15   ├─ /blog/building-with-swift-trunk/index.html (+0ms)
15:45:15   ├─ /blog/calling-super-at-runtime/index.html (+0ms)
15:45:15   ├─ /blog/couldnt-irgen-expression/index.html (+0ms)
15:45:15   ├─ /blog/curating-your-twitter-timeline/index.html (+0ms)
15:45:15   ├─ /blog/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+0ms)
15:45:15   ├─ /blog/dont-call-willchangevalueforkey/index.html (+0ms)
15:45:15   ├─ /blog/fixing-keyboardshortcut-in-swiftui/index.html (+0ms)
15:45:15   ├─ /blog/fixing-uisearchdisplaycontroller-on-ios-7/index.html (+0ms)
15:45:15   ├─ /blog/fixing-uitextview-on-ios-7/index.html (+0ms)
15:45:15   ├─ /blog/fixing-what-apple-doesnt/index.html (+0ms)
15:45:15   ├─ /blog/forbidden-controls-in-catalyst-mac-idiom/index.html (+0ms)
15:45:15   ├─ /blog/growing-your-twitter-followers/index.html (+0ms)
15:45:15   ├─ /blog/hacking-block-support-into-uimenuitem/index.html (+0ms)
15:45:15   ├─ /blog/hacking-with-aspects/index.html (+0ms)
15:45:15   ├─ /blog/how-to-center-uiscrollview/index.html (+0ms)
15:45:15   ├─ /blog/how-to-inspect-the-view-hierarchy-of-3rd-party-apps/index.html (+0ms)
15:45:15   ├─ /blog/how-to-macos-core-dump/index.html (+0ms)
15:45:15   ├─ /blog/interposekit/index.html (+0ms)
15:45:15   ├─ /blog/jailbreaking-for-ios-developers/index.html (+0ms)
15:45:15   ├─ /blog/kernel-panic-surprise-boot-args/index.html (+0ms)
15:45:15   ├─ /blog/lets-try-this-again/index.html (+0ms)
15:45:15   ├─ /blog/logging-in-swift/index.html (+0ms)
15:45:15   ├─ /blog/mac-catalyst-crash-hunt/index.html (+0ms)
15:45:15   ├─ /blog/moving-on/index.html (+0ms)
15:45:15   ├─ /blog/network-kernel-core-dump/index.html (+0ms)
15:45:15   ├─ /blog/nsurlcache-uses-a-disk-cache-as-of-ios5/index.html (+0ms)
15:45:15   ├─ /blog/pimping-recursivedescription/index.html (+0ms)
15:45:15   ├─ /blog/reboot/index.html (+0ms)
15:45:15   ├─ /blog/researching-researchkit/index.html (+0ms)
15:45:15   ├─ /blog/retrofitting-containsstring-on-ios-7/index.html (+0ms)
15:45:15   ├─ /blog/rotation-multiple-windows-bug/index.html (+0ms)
15:45:15   ├─ /blog/smart-proxy-delegation/index.html (+0ms)
15:45:15   ├─ /blog/state-of-swiftui/index.html (+0ms)
15:45:15   ├─ /blog/supporting-both-tap-and-longpress-on-button-in-swiftui/index.html (+0ms)
15:45:15   ├─ /blog/the-lg-ultrafine5k-kerneltask-and-me/index.html (+0ms)
15:45:15   ├─ /blog/top-level-menu-visibility-in-swiftui/index.html (+0ms)
15:45:15   ├─ /blog/uiappearance-for-custom-views/index.html (+0ms)
15:45:15   ├─ /blog/uikit-debug-mode/index.html (+0ms)
15:45:15   ├─ /blog/uitableviewcontroller-designated-initializer-woes/index.html (+0ms)
15:45:15   ├─ /blog/updating-a-hackintosh/index.html (+0ms)
15:45:15   ├─ /blog/using-subscripting-with-xcode-4_4-and-ios-4_3/index.html (+0ms)
15:45:15   └─ /blog/zld-a-faster-linker/index.html (+0ms)
15:45:15 ▶ src/pages/page/[page].astro
15:45:15   ├─ /page/1/index.html (+2ms)
15:45:15   ├─ /page/2/index.html (+2ms)
15:45:15   ├─ /page/3/index.html (+1ms)
15:45:15   ├─ /page/4/index.html (+2ms)
15:45:15   ├─ /page/5/index.html (+1ms)
15:45:15   ├─ /page/6/index.html (+4ms)
15:45:15   └─ /page/7/index.html (+2ms)
15:45:15 ▶ src/pages/posts/[page].astro
15:45:15   ├─ /posts/2/index.html (+2ms)
15:45:15   ├─ /posts/3/index.html (+1ms)
15:45:15   ├─ /posts/4/index.html (+1ms)
15:45:15   ├─ /posts/5/index.html (+1ms)
15:45:16   ├─ /posts/6/index.html (+1ms)
15:45:16   └─ /posts/7/index.html (+1ms)
15:45:16 ▶ src/pages/posts/index.astro
15:45:16   └─ /posts/index.html (+1ms)
15:45:16 ▶ src/pages/posts/[...slug].astro
15:45:16   ├─ /posts/2020-05-14-lets-try-this-again/index.html (+2ms)
15:45:16   ├─ /posts/2020-05-19-how-to-macos-core-dump/index.html (+1ms)
15:45:16   ├─ /posts/2020-05-19-kernel-panic-surprise-boot-args/index.html (+1ms)
15:45:16   ├─ /posts/2020-05-19-the-lg-ultrafine5k-kerneltask-and-me/index.html (+3ms)
15:45:16   ├─ /posts/2020-05-21-network-kernel-core-dump/index.html (+1ms)
15:45:16   ├─ /posts/2020-05-26-jailbreaking-for-ios-developers/index.html (+1ms)
15:45:16   ├─ /posts/2020-05-30-mac-catalyst-crash-hunt/index.html (+1ms)
15:45:16   ├─ /posts/2020-05-31-interposekit/index.html (+1ms)
15:45:16   ├─ /posts/2020-06-01-updating-a-hackintosh/index.html (+1ms)
15:45:16   ├─ /posts/2020-06-04-couldnt-irgen-expression/index.html (+1ms)
15:45:16   ├─ /posts/2020-06-05-zld-a-faster-linker/index.html (+1ms)
15:45:16   ├─ /posts/2020-06-10-calling-super-at-runtime/index.html (+2ms)
15:45:16   ├─ /posts/2020-06-12-building-with-swift-trunk/index.html (+1ms)
15:45:16   ├─ /posts/2020-08-22-logging-in-swift/index.html (+2ms)
15:45:16   ├─ /posts/2020-09-21-disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+1ms)
15:45:16   ├─ /posts/2020-09-22-forbidden-controls-in-catalyst-mac-idiom/index.html (+1ms)
15:45:16   ├─ /posts/2020-10-21-curating-your-twitter-timeline/index.html (+1ms)
15:45:16   ├─ /posts/2020-10-21-growing-your-twitter-followers/index.html (+1ms)
15:45:16   ├─ /posts/a-new-beginning/index.html (+1ms)
15:45:16   ├─ /posts/a-story-about-swizzling-the-right-way-and-touch-forwarding/index.html (+1ms)
15:45:16   ├─ /posts/adding-keyboard-shortcuts-to-uialertview/index.html (+3ms)
15:45:16   ├─ /posts/apple-silicon-m1-a-developer-perspective/index.html (+1ms)
15:45:16   ├─ /posts/apple-silicon-mac-mini-for-ci/index.html (+1ms)
15:45:16   ├─ /posts/building-with-swift-trunk/index.html (+1ms)
15:45:16   ├─ /posts/calling-super-at-runtime/index.html (+1ms)
15:45:16   ├─ /posts/couldnt-irgen-expression/index.html (+1ms)
15:45:16   ├─ /posts/curating-your-twitter-timeline/index.html (+1ms)
15:45:16   ├─ /posts/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+1ms)
15:45:16   ├─ /posts/dont-call-willchangevalueforkey/index.html (+1ms)
15:45:16   ├─ /posts/fixing-keyboardshortcut-in-swiftui/index.html (+1ms)
15:45:16   ├─ /posts/fixing-uisearchdisplaycontroller-on-ios-7/index.html (+1ms)
15:45:16   ├─ /posts/fixing-uitextview-on-ios-7/index.html (+1ms)
15:45:16   ├─ /posts/fixing-what-apple-doesnt/index.html (+1ms)
15:45:16   ├─ /posts/forbidden-controls-in-catalyst-mac-idiom/index.html (+1ms)
15:45:16   ├─ /posts/growing-your-twitter-followers/index.html (+1ms)
15:45:16   ├─ /posts/hacking-block-support-into-uimenuitem/index.html (+1ms)
15:45:16   ├─ /posts/hacking-with-aspects/index.html (+2ms)
15:45:16   ├─ /posts/how-to-center-uiscrollview/index.html (+1ms)
15:45:16   ├─ /posts/how-to-inspect-the-view-hierarchy-of-3rd-party-apps/index.html (+1ms)
15:45:16   ├─ /posts/how-to-macos-core-dump/index.html (+1ms)
15:45:16   ├─ /posts/interposekit/index.html (+1ms)
15:45:16   ├─ /posts/jailbreaking-for-ios-developers/index.html (+1ms)
15:45:16   ├─ /posts/kernel-panic-surprise-boot-args/index.html (+1ms)
15:45:16   ├─ /posts/lets-try-this-again/index.html (+1ms)
15:45:16   ├─ /posts/logging-in-swift/index.html (+1ms)
15:45:16   ├─ /posts/mac-catalyst-crash-hunt/index.html (+1ms)
15:45:16   ├─ /posts/moving-on/index.html (+1ms)
15:45:16   ├─ /posts/network-kernel-core-dump/index.html (+1ms)
15:45:16   ├─ /posts/nsurlcache-uses-a-disk-cache-as-of-ios5/index.html (+1ms)
15:45:16   ├─ /posts/pimping-recursivedescription/index.html (+1ms)
15:45:16   ├─ /posts/reboot/index.html (+1ms)
15:45:16   ├─ /posts/researching-researchkit/index.html (+1ms)
15:45:16   ├─ /posts/retrofitting-containsstring-on-ios-7/index.html (+1ms)
15:45:16   ├─ /posts/rotation-multiple-windows-bug/index.html (+2ms)
15:45:16   ├─ /posts/smart-proxy-delegation/index.html (+1ms)
15:45:16   ├─ /posts/state-of-swiftui/index.html (+1ms)
15:45:16   ├─ /posts/supporting-both-tap-and-longpress-on-button-in-swiftui/index.html (+1ms)
15:45:16   ├─ /posts/the-lg-ultrafine5k-kerneltask-and-me/index.html (+1ms)
15:45:16   ├─ /posts/top-level-menu-visibility-in-swiftui/index.html (+1ms)
15:45:16   ├─ /posts/uiappearance-for-custom-views/index.html (+1ms)
15:45:16   ├─ /posts/uikit-debug-mode/index.html (+1ms)
15:45:16   ├─ /posts/uitableviewcontroller-designated-initializer-woes/index.html (+1ms)
15:45:16   ├─ /posts/updating-a-hackintosh/index.html (+1ms)
15:45:16   ├─ /posts/using-subscripting-with-xcode-4_4-and-ios-4_3/index.html (+1ms)
15:45:16   └─ /posts/zld-a-faster-linker/index.html (+1ms)
15:45:16 λ src/pages/rss.xml.js
15:45:16   └─ /rss.xml (+2ms)
15:45:16 ▶ src/pages/[year]/[month]/[day]/[slug].astro
15:45:16   ├─ /2020/05/14/lets-try-this-again/index.html (+0ms)
15:45:16   ├─ /2020/05/19/how-to-macos-core-dump/index.html (+0ms)
15:45:16   ├─ /2020/05/19/kernel-panic-surprise-boot-args/index.html (+0ms)
15:45:16   ├─ /2020/05/19/the-lg-ultrafine5k-kerneltask-and-me/index.html (+0ms)
15:45:16   ├─ /2020/05/21/network-kernel-core-dump/index.html (+0ms)
15:45:16   ├─ /2020/05/26/jailbreaking-for-ios-developers/index.html (+0ms)
15:45:16   ├─ /2020/05/30/mac-catalyst-crash-hunt/index.html (+0ms)
15:45:16   ├─ /2020/05/31/interposekit/index.html (+0ms)
15:45:16   ├─ /2020/06/01/updating-a-hackintosh/index.html (+0ms)
15:45:16   ├─ /2020/06/04/couldnt-irgen-expression/index.html (+0ms)
15:45:16   ├─ /2020/06/05/zld-a-faster-linker/index.html (+1ms)
15:45:16   ├─ /2020/06/10/calling-super-at-runtime/index.html (+0ms)
15:45:16   ├─ /2020/06/12/building-with-swift-trunk/index.html (+0ms)
15:45:16   ├─ /2020/08/22/logging-in-swift/index.html (+0ms)
15:45:16   ├─ /2020/09/21/disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+0ms)
15:45:16   ├─ /2020/09/22/forbidden-controls-in-catalyst-mac-idiom/index.html (+0ms)
15:45:16   ├─ /2020/10/21/curating-your-twitter-timeline/index.html (+0ms)
15:45:16   └─ /2020/10/21/growing-your-twitter-followers/index.html (+0ms)
15:45:16 ▶ src/pages/[old_slug].astro
15:45:16   ├─ /2020-05-14-lets-try-this-again/index.html (+0ms)
15:45:16   ├─ /2020-05-19-how-to-macos-core-dump/index.html (+0ms)
15:45:16   ├─ /2020-05-19-kernel-panic-surprise-boot-args/index.html (+0ms)
15:45:16   ├─ /2020-05-19-the-lg-ultrafine5k-kerneltask-and-me/index.html (+0ms)
15:45:16   ├─ /2020-05-21-network-kernel-core-dump/index.html (+0ms)
15:45:16   ├─ /2020-05-26-jailbreaking-for-ios-developers/index.html (+0ms)
15:45:16   ├─ /2020-05-30-mac-catalyst-crash-hunt/index.html (+0ms)
15:45:16   ├─ /2020-05-31-interposekit/index.html (+0ms)
15:45:16   ├─ /2020-06-01-updating-a-hackintosh/index.html (+0ms)
15:45:16   ├─ /2020-06-04-couldnt-irgen-expression/index.html (+0ms)
15:45:16   ├─ /2020-06-05-zld-a-faster-linker/index.html (+0ms)
15:45:16   ├─ /2020-06-10-calling-super-at-runtime/index.html (+0ms)
15:45:16   ├─ /2020-06-12-building-with-swift-trunk/index.html (+0ms)
15:45:16   ├─ /2020-08-22-logging-in-swift/index.html (+0ms)
15:45:16   ├─ /2020-09-21-disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+0ms)
15:45:16   ├─ /2020-09-22-forbidden-controls-in-catalyst-mac-idiom/index.html (+0ms)
15:45:16   ├─ /2020-10-21-curating-your-twitter-timeline/index.html (+0ms)
15:45:16   ├─ /2020-10-21-growing-your-twitter-followers/index.html (+0ms)
15:45:16   ├─ /a-new-beginning/index.html (+0ms)
15:45:16   ├─ /a-story-about-swizzling-the-right-way-and-touch-forwarding/index.html (+0ms)
15:45:16   ├─ /adding-keyboard-shortcuts-to-uialertview/index.html (+0ms)
15:45:16   ├─ /apple-silicon-m1-a-developer-perspective/index.html (+0ms)
15:45:16   ├─ /apple-silicon-mac-mini-for-ci/index.html (+0ms)
15:45:16   ├─ /building-with-swift-trunk/index.html (+0ms)
15:45:16   ├─ /calling-super-at-runtime/index.html (+0ms)
15:45:16   ├─ /couldnt-irgen-expression/index.html (+0ms)
15:45:16   ├─ /curating-your-twitter-timeline/index.html (+0ms)
15:45:16   ├─ /disabling-keyboard-avoidance-in-swiftui-uihostingcontroller/index.html (+0ms)
15:45:16   ├─ /dont-call-willchangevalueforkey/index.html (+0ms)
15:45:16   ├─ /fixing-keyboardshortcut-in-swiftui/index.html (+0ms)
15:45:16   ├─ /fixing-uisearchdisplaycontroller-on-ios-7/index.html (+0ms)
15:45:16   ├─ /fixing-uitextview-on-ios-7/index.html (+0ms)
15:45:16   ├─ /fixing-what-apple-doesnt/index.html (+0ms)
15:45:16   ├─ /forbidden-controls-in-catalyst-mac-idiom/index.html (+0ms)
15:45:16   ├─ /growing-your-twitter-followers/index.html (+0ms)
15:45:16   ├─ /hacking-block-support-into-uimenuitem/index.html (+0ms)
15:45:16   ├─ /hacking-with-aspects/index.html (+0ms)
15:45:16   ├─ /how-to-center-uiscrollview/index.html (+0ms)
15:45:16   ├─ /how-to-inspect-the-view-hierarchy-of-3rd-party-apps/index.html (+0ms)
15:45:16   ├─ /how-to-macos-core-dump/index.html (+0ms)
15:45:16   ├─ /interposekit/index.html (+0ms)
15:45:16   ├─ /jailbreaking-for-ios-developers/index.html (+0ms)
15:45:16   ├─ /kernel-panic-surprise-boot-args/index.html (+0ms)
15:45:16   ├─ /lets-try-this-again/index.html (+0ms)
15:45:16   ├─ /logging-in-swift/index.html (+0ms)
15:45:16   ├─ /mac-catalyst-crash-hunt/index.html (+0ms)
15:45:16   ├─ /moving-on/index.html (+0ms)
15:45:16   ├─ /network-kernel-core-dump/index.html (+0ms)
15:45:16   ├─ /nsurlcache-uses-a-disk-cache-as-of-ios5/index.html (+0ms)
15:45:16   ├─ /pimping-recursivedescription/index.html (+0ms)
15:45:16   ├─ /reboot/index.html (+0ms)
15:45:16   ├─ /researching-researchkit/index.html (+0ms)
15:45:16   ├─ /retrofitting-containsstring-on-ios-7/index.html (+0ms)
15:45:16   ├─ /rotation-multiple-windows-bug/index.html (+0ms)
15:45:16   ├─ /smart-proxy-delegation/index.html (+0ms)
15:45:16   ├─ /state-of-swiftui/index.html (+0ms)
15:45:16   ├─ /supporting-both-tap-and-longpress-on-button-in-swiftui/index.html (+0ms)
15:45:16   ├─ /the-lg-ultrafine5k-kerneltask-and-me/index.html (+0ms)
15:45:16   ├─ /top-level-menu-visibility-in-swiftui/index.html (+0ms)
15:45:16   ├─ /uiappearance-for-custom-views/index.html (+0ms)
15:45:16   ├─ /uikit-debug-mode/index.html (+0ms)
15:45:16   ├─ /uitableviewcontroller-designated-initializer-woes/index.html (+0ms)
15:45:16   ├─ /updating-a-hackintosh/index.html (+0ms)
15:45:16   ├─ /using-subscripting-with-xcode-4_4-and-ios-4_3/index.html (+0ms)
15:45:16   └─ /zld-a-faster-linker/index.html (+0ms)
15:45:16 ▶ src/pages/index.astro
15:45:16   └─ /index.html (+1ms)
15:45:16 ✓ Completed in 168ms.

15:45:16 [@astrojs/sitemap] `sitemap-index.xml` created at `dist`
15:45:16 [build] 236 page(s) built in 2.73s
15:45:16 [build] Complete!
- View code blocks in dark mode to verify improved readability
- Verify syntax highlighting is brighter and more legible