### PR TITLE
Fix theme persistence across page navigation

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -74,9 +74,10 @@ const fullTitle = title === SITE.title ? title : `${title} | ${SITE.title}`
 
 <!-- Dark Mode Detection -->
 <script is:inline>
-  // Set theme based on system preferences
+  // Check localStorage first, then fallback to system preferences
+  const storedTheme = localStorage.getItem('theme')
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  const theme = prefersDark ? 'dark' : 'light'
+  const theme = storedTheme || (prefersDark ? 'dark' : 'light')
 
   if (theme === 'dark') {
     document.documentElement.classList.add('dark')
@@ -84,14 +85,16 @@ const fullTitle = title === SITE.title ? title : `${title} | ${SITE.title}`
     document.documentElement.classList.remove('dark')
   }
 
-  // Listen for changes in system preference
-  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-    if (e.matches) {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  })
+  // Listen for changes in system preference (only if no user preference is set)
+  if (!storedTheme) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+      if (e.matches) {
+        document.documentElement.classList.add('dark')
+      } else {
+        document.documentElement.classList.remove('dark')
+      }
+    })
+  }
 </script>
 
 <slot />

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -9,9 +9,10 @@
     localStorage.setItem('theme', theme)
   }
 
-  // Set theme based on system preferences
+  // Check localStorage first, then fallback to system preferences
+  const storedTheme = localStorage.getItem('theme')
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-  const theme = prefersDark ? 'dark' : 'light'
+  const theme = storedTheme || (prefersDark ? 'dark' : 'light')
 
   if (theme === 'dark') {
     document.documentElement.classList.add('dark')


### PR DESCRIPTION
## Summary
- Fixes the theme toggle to persist user's preference across page navigation
- Stores theme preference in localStorage and reads it on page load
- Checks localStorage first, then falls back to system preference
- Only listens for system theme changes if user hasn't set a preference

## Test plan
1. Visit any page on the site
2. Toggle the theme (light/dark)
3. Navigate to a different page
4. Verify that the selected theme persists

🤖 Generated with [Claude Code](https://claude.ai/code)