### PR TITLE
Improve YouTube embed documentation and examples

### DIFF
--- a/docs/YOUTUBE.MD
+++ b/docs/YOUTUBE.MD
@@ -2,7 +2,7 @@
 
 This document provides a quick guide on how to use YouTube embeds in blog posts.
 
-## Using the YouTube Embed Tag
+## Using the YouTube Embed Tag (Recommended Method)
 
 To embed a YouTube video, use the following syntax:
 
@@ -36,6 +36,21 @@ Using a youtu.be short URL:
 
 The site uses the `MDXTwitterTransform.astro` component to scan for these patterns in blog post content and replace them with proper YouTube embeds. The component detects special tags using regex and inserts responsive iframes.
 
+## Component-Based Approach (Not Recommended)
+
+There's also a direct component approach, but the tag-based method above is preferred:
+
+```astro
+<YouTubeEmbed id="dQw4w9WgXcQ" title="Video Title" />
+```
+
+This approach has several drawbacks:
+- It requires importing the component
+- It's less consistent with our Twitter embed syntax
+- It's not automatically processed by our content transformation pipeline
+
+**Note:** When using the component-based approach, the MDX compiler will issue warnings about unused variables. The tag-based method avoids these issues.
+
 ## Twitter Embeds for Comparison
 
 Twitter embeds work in a similar way:
@@ -46,7 +61,9 @@ Twitter embeds work in a similar way:
 
 ## Best Practices
 
-1. Always use the `{% youtube %}` syntax instead of direct iframe embeds
+1. Always use the `{% youtube %}` syntax instead of direct iframe embeds or the component
 2. This ensures content won't be blocked by privacy-focused browsers
 3. The embed is responsive and will adjust to different screen sizes
 4. Works with all YouTube URL formats (full youtube.com URLs, youtu.be short URLs, or just the video ID)
+5. Keeps consistency with our Twitter embed syntax
+6. Avoids linting warnings

--- a/src/content/blog/2025/using-youtube-embeds.md
+++ b/src/content/blog/2025/using-youtube-embeds.md
@@ -8,9 +8,9 @@ tags:
 AIDescription: true
 ---
 
-This post demonstrates how to use YouTube embeds in blog posts using the new syntax.
+This post demonstrates how to use YouTube embeds in blog posts using the recommended syntax.
 
-## Using the YouTube Embed Tag
+## Using the YouTube Embed Tag (Recommended Method)
 
 To embed a YouTube video, use the following syntax:
 
@@ -34,12 +34,31 @@ Using a youtu.be short URL:
 
 {% youtube https://youtu.be/dQw4w9WgXcQ %}
 
+## Why Tag-Based Approach is Better
+
+The tag-based approach has several advantages:
+- Consistency with Twitter embeds syntax
+- No component imports required
+- Automatic processing by our content transformation pipeline
+- No linting warnings from unused variables
+- Better separation of content and presentation
+
 ## Twitter Embeds for Comparison
 
 For reference, here's how Twitter embeds work:
 
 {% twitter https://twitter.com/steipete/status/1134003594804547584 %}
 
+## Component-Based Approach (Not Recommended)
+
+There's also a direct component approach, but it's not recommended:
+
+```astro
+<YouTubeEmbed id="dQw4w9WgXcQ" title="Video Title" />
+```
+
+This approach creates linting warnings and is less consistent with our established patterns.
+
 ## Conclusion
 
-Now you can easily embed YouTube videos in your blog posts using the same pattern as Twitter embeds. The embed is responsive and will adjust to different screen sizes.
+Always use the `{% youtube %}` tag syntax for embedding YouTube videos in your blog posts. The embed is responsive and will adjust to different screen sizes, and you'll avoid the linting warnings associated with the component-based approach.


### PR DESCRIPTION
## Summary
- Update documentation to clearly distinguish between tag-based and component-based YouTube embed approaches
- Add specific warnings about linting issues with the component-based approach
- Document the root cause of the unused variable warnings seen in PRs
- Update the example blog post to be consistent with documentation
- Establish the tag-based approach (`{% youtube %}`) as the standard method

## Background
Previous PRs revealed linting warnings related to YouTube embeds. This PR addresses those issues by:
1. Documenting why the warnings occur
2. Recommending the tag-based approach which doesn't cause linting warnings
3. Making our documentation and examples consistent

## Test plan
- Build the site to verify documentation renders correctly
- Verify example blog post correctly demonstrates the recommended approach

🤖 Generated with [Claude Code](https://claude.ai/code)