### PR TITLE
Remove import posts section and fix Twitter embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,6 @@ I'm Peter Steinberger, an iOS developer, entrepreneur, and open source contribut
 | `npm run dev`          | Starts local dev server at `localhost:4321` |
 | `npm run build`        | Build the production site to `./dist/`      |
 | `npm run preview`      | Preview the build locally, before deploying |
-| `npm run import-posts` | Import posts from GitHub repositories       |
-
-## Import Blog Posts
-
-This project includes a script to import blog posts from my previous GitHub repositories:
-
-```bash
-npm run import-posts
-```
-
-This will fetch and convert posts from:
-
-- https://github.com/steipete/steipete.com
-- https://github.com/steipete/petersteinberger.com
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,6 @@
     "build:check": "astro check && astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
-    "import-posts": "node scripts/import-posts.mjs",
-    "convert-posts": "node scripts/convert-posts.mjs",
     "deploy": "scripts/deploy.sh",
     "add-source-metadata": "node scripts/add-source-metadata.mjs",
     "remove-tags": "node scripts/remove-tags-from-posts.mjs",

--- a/src/content/blog/2025/finding-my-spark-again.md
+++ b/src/content/blog/2025/finding-my-spark-again.md
@@ -13,8 +13,6 @@ source: steipete.com
 
 <blockquote class="twitter-tweet" data-width="550" data-theme="light" data-dnt="true"><p lang="en" dir="ltr">We are so back 🚀</p>&mdash; Peter Steinberger (@steipete) <a href="https://twitter.com/steipete/status/1925983535958999393?ref_src=twsrc%5Etfw">November 20, 2024</a></blockquote>
 
-<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
-
 When I sold my shares of [PSPDFKit](https://www.nutrient.io/) after building the company and making it my identity for over 13 years, I was very broken. I've been pouring 200% of my time, energy, and heart's blood into this company, and towards the end, I just felt that I needed a break. We've been very lucky to have found an amazing company with Insight, that acquired the majority.
 
 ## The Emptiness After


### PR DESCRIPTION
## Summary
- Remove outdated "Import Blog Posts" section from README
- Remove import-posts and convert-posts scripts from package.json
- Fix Twitter embed not expanding by removing duplicate script tag

## Context
This is a fresh PR created from the latest main branch to avoid merge conflicts from the previous PR #69.

## Changes Made
1. **README cleanup**: Removed the entire "Import Blog Posts" section as it's no longer needed
2. **Script cleanup**: Removed `import-posts` and `convert-posts` commands from package.json
3. **Twitter embed fix**: Removed duplicate script tag from the "Finding My Spark Again" post - the BlogPostLayout already handles Twitter widget loading

## Test Plan
- [x] Verify Twitter embed loads correctly in the "Finding My Spark Again" post
- [x] Confirm README no longer contains import posts section
- [x] Check that package.json scripts have been cleaned up

🤖 Generated with [Claude Code](https://claude.ai/code)