### PR TITLE
Add speaking section and fix GitHub contributions graph

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -15,11 +15,13 @@ title: "About"
   </div>
 </div>
 
+I'm looking for new opportunities to share my learnings at conferences. [Check out my speaking history and topics](https://github.com/steipete/speaking).
+
 ## GitHub Contributions
 
 <div class="bg-secondary p-6 rounded-lg">
   <img 
-    src="https://ghchart.rshah.org/409ba5/steipete" 
+    src="https://ghchart.rshah.org/steipete" 
     alt="GitHub Contributions Graph" 
     class="w-full"
     loading="lazy"


### PR DESCRIPTION
## Summary
- Add sentence about conference speaking opportunities to About page
- Fix GitHub contributions graph URL

## Changes Made
1. **Speaking section**: Added "I'm looking for new opportunities to share my learnings at conferences" with a link to the speaking GitHub repository
2. **GitHub graph fix**: Removed the color code from the ghchart URL to use default styling (the 409ba5 color code was causing 404 errors)

## Test Plan
- [x] Verify the speaking link points to the correct repository
- [x] Check that the GitHub contributions graph loads correctly

🤖 Generated with [Claude Code](https://claude.ai/code)