### PR TITLE
Fix /posts redirect to enable archive page access

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,6 @@
   "framework": "astro",
   "trailingSlash": false,
   "redirects": [
-    { "source": "/posts", "destination": "/", "permanent": true },
     {
       "source": "/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug",
       "destination": "/blog/:slug/",


### PR DESCRIPTION
## Summary
- Removed the redirect from `/posts` to `/` in vercel.json that was preventing access to the blog archive page

## Context
The `/posts` route was being redirected to the home page on Vercel, which prevented users from accessing the full blog archive. This was working correctly in development but failing on the deployed site due to the redirect rule.

## Changes
- Removed line 9 from vercel.json: `{ "source": "/posts", "destination": "/", "permanent": true },`

This allows the `/posts` route to function properly and display the blog archive as intended.

🤖 Generated with [Claude Code](https://claude.ai/code)