### PR TITLE
Fix favicon references and Twitter widget loading

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -4,10 +4,9 @@
   "description": "iOS developer, entrepreneur, founder of PSPDFKit (acquired), vibe coding my next project",
   "icons": [
     {
-      "src": "/favicon.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
-      "purpose": "any maskable"
+      "src": "/favicon.ico",
+      "sizes": "16x16 32x32 48x48",
+      "type": "image/x-icon"
     }
   ],
   "start_url": "/",

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -27,7 +27,7 @@ const fullTitle = title === SITE.title ? title : `${title} | ${SITE.title}`;
 <meta name="author" content={SITE.author} />
 
 <!-- Favicon -->
-<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 <link rel="manifest" href="/site.webmanifest" />
 
 <!-- Primary Meta Tags -->

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -221,10 +221,23 @@ const canonicalURL = new URL(canonicalPath, Astro.site);
 
     // Load Twitter widgets script if we found Twitter embeds
     if (foundTwitterEmbeds) {
-      const script = document.createElement("script");
-      script.src = "https://platform.twitter.com/widgets.js";
-      script.async = true;
-      document.head.appendChild(script);
+      // Check if script is already loaded
+      if (!document.querySelector('script[src="https://platform.twitter.com/widgets.js"]')) {
+        const script = document.createElement("script");
+        script.src = "https://platform.twitter.com/widgets.js";
+        script.async = true;
+        document.body.appendChild(script);
+        
+        // Force re-render of tweets after script loads
+        script.onload = () => {
+          if (window.twttr && window.twttr.widgets) {
+            window.twttr.widgets.load();
+          }
+        };
+      } else if (window.twttr && window.twttr.widgets) {
+        // If script is already loaded, just reload widgets
+        window.twttr.widgets.load();
+      }
     }
   }
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -53,7 +53,7 @@ const structuredData = {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="canonical" href={canonicalURL} />
     <meta name="generator" content={Astro.generator} />
 


### PR DESCRIPTION
## Summary
- Fixed all remaining favicon.svg references to use favicon.ico
- Fixed Twitter widget not loading/expanding on blog posts

## Changes
- Updated favicon links in BaseHead.astro and Layout.astro to use favicon.ico
- Updated site.webmanifest to reference favicon.ico with proper icon sizes
- Fixed Twitter widget script loading by:
  - Appending script to body instead of head
  - Adding onload handler to force widget rendering
  - Preventing duplicate script loading
  - Calling twttr.widgets.load() when script is already loaded

## Test plan
- [ ] Verify favicon displays correctly in browser tabs
- [ ] Check that Twitter embeds expand properly on blog posts
- [ ] Confirm no console errors related to favicon or Twitter widgets
- [ ] Test page navigation to ensure Twitter widgets still work

🤖 Generated with [Claude Code](https://claude.ai/code)