### PR TITLE
Fix Twitter widget not loading in production

### DIFF
--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -219,31 +219,31 @@ const canonicalURL = new URL(canonicalPath, Astro.site);
       }
     });
 
-    // Load Twitter widgets script if we found Twitter embeds
-    if (foundTwitterEmbeds) {
-      // Check if script is already loaded
-      if (!document.querySelector('script[src="https://platform.twitter.com/widgets.js"]')) {
-        const script = document.createElement("script");
-        script.src = "https://platform.twitter.com/widgets.js";
-        script.async = true;
-        document.body.appendChild(script);
-        
-        // Force re-render of tweets after script loads
-        script.onload = () => {
-          if (window.twttr && window.twttr.widgets) {
-            window.twttr.widgets.load();
-          }
-        };
-      } else if (window.twttr && window.twttr.widgets) {
-        // If script is already loaded, just reload widgets
-        window.twttr.widgets.load();
-      }
+    // Force Twitter widgets to load if we found Twitter embeds
+    if (foundTwitterEmbeds && window.twttr && window.twttr.widgets) {
+      window.twttr.widgets.load();
     }
   }
 
   // Run the embed processing
   document.addEventListener("DOMContentLoaded", processEmbeds);
   document.addEventListener("astro:page-load", processEmbeds);
+  
+  // Also try processing on window load as a fallback
+  window.addEventListener("load", () => {
+    // Check if there are unprocessed Twitter embeds
+    const unprocessedTweets = document.querySelectorAll('blockquote.twitter-tweet:not([data-twitter-extracted-i])');
+    if (unprocessedTweets.length > 0) {
+      processEmbeds();
+    }
+    
+    // Force Twitter widgets to load after a delay
+    setTimeout(() => {
+      if (window.twttr && window.twttr.widgets) {
+        window.twttr.widgets.load();
+      }
+    }, 1000);
+  });
 </script>
 
 <style>
@@ -271,4 +271,6 @@ const canonicalURL = new URL(canonicalPath, Astro.site);
     border: 0;
   }
 </style>
+  <!-- Twitter Widget Script -->
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </Layout>


### PR DESCRIPTION
## Summary
Fixed Twitter widget embeds not expanding/loading on production site

## Problem
Twitter embeds work locally but fail to load on the production site at steipete.me, likely due to Content Security Policy restrictions or timing issues with script loading.

## Solution
- Added Twitter widgets.js script tag directly in the BlogPostLayout instead of dynamic injection
- Simplified the widget loading logic to avoid CSP issues
- Added multiple fallback mechanisms:
  - Load on DOMContentLoaded
  - Load on astro:page-load
  - Load on window.load
  - Force reload after 1 second delay
- This ensures the Twitter widget script is always available and properly initialized

## Test plan
- [ ] Deploy to production
- [ ] Visit https://steipete.me/posts/2025/finding-my-spark-again
- [ ] Verify Twitter embed expands and shows the tweet content
- [ ] Check browser console for any CSP errors

🤖 Generated with [Claude Code](https://claude.ai/code)