### PR TITLE
Fix GitHub graph margin and Twitter widget loading

### DIFF
--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -271,6 +271,7 @@ const canonicalURL = new URL(canonicalPath, Astro.site);
     border: 0;
   }
 </style>
-  <!-- Twitter Widget Script -->
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  
+  <!-- Twitter Widget Script - Load as external script -->
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8" is:inline={false}></script>
 </Layout>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -129,6 +129,9 @@ const structuredData = {
     <ClientRouter />
 
     <script is:inline src="/toggle-theme.js"></script>
+    
+    <!-- Twitter Widget Script -->
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   </head>
   <body>
     <slot />

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -19,7 +19,7 @@ I'm looking for new opportunities to share my learnings at conferences. [Check o
 
 ## GitHub Activity
 
-<div class="bg-secondary p-2 sm:p-6 rounded-lg">
+<div class="bg-secondary p-0 rounded-lg">
   <img 
     src="https://ghchart.rshah.org/steipete" 
     alt="Peter's GitHub Contribution Graph" 


### PR DESCRIPTION
## Summary
- Remove padding from GitHub activity graph on About page
- Fix Twitter widget loading issue in production

## Changes

### GitHub Activity Graph
- Changed padding from `p-2 sm:p-6` to `p-0` to remove all margin/padding
- Graph now displays edge-to-edge within its container

### Twitter Widget Fix
- Added Twitter widgets.js script to the main Layout.astro head section
- Script now loads properly on all pages that use the Layout
- This should fix the issue where Twitter embeds weren't expanding on production

## Test Plan
- [x] Verify GitHub graph displays without padding on About page
- [ ] Deploy to production and verify Twitter embeds expand properly
- [ ] Check that Twitter widgets.js loads in browser network tab
- [ ] Confirm no console errors related to Twitter widgets

🤖 Generated with [Claude Code](https://claude.ai/code)