### PR TITLE
Reduce About page image size by another 10%

### DIFF
--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -4,7 +4,7 @@ title: "About"
 ---
 
 <div class="flex flex-col md:flex-row gap-8 items-start">
-  <div class="w-full md:w-auto md:flex-shrink-0 md:max-w-[340px]">
+  <div class="w-full md:w-auto md:flex-shrink-0 md:max-w-[306px]">
     <img src="/peter-office.jpg" alt="Peter in his office setup" class="w-full h-auto rounded-lg" />
   </div>
   <div class="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
Further reduce the About page image size on desktop by 10%

## Changes
- Changed `md:max-w-[340px]` to `md:max-w-[306px]`
- This is a 10% reduction from the current size
- Total reduction from original 400px is now 23.5%
- Mobile view remains unchanged (full width)

🤖 Generated with [Claude Code](https://claude.ai/code)