### PR TITLE
Fix date field alignment and spacing

### DIFF
--- a/src/components/Datetime.astro
+++ b/src/components/Datetime.astro
@@ -32,11 +32,11 @@ const datetime = dayjs(latestDatetime).tz(postTimezone || SITE.timezone);
 const date = datetime.format("D MMM, YYYY"); // e.g., '22 Mar, 2025'
 ---
 
-<div class:list={["flex items-end space-x-2 opacity-80", className]}>
+<div class:list={["flex items-center gap-2 opacity-80", className]}>
   <IconCalendar
     class:list={[
-      "inline-block size-6 min-w-[1.375rem]",
-      { "scale-90": size === "sm" },
+      "inline-block size-5 min-w-[1.25rem]",
+      { "size-4 min-w-[1rem]": size === "sm" },
     ]}
   />
   {

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -97,11 +97,11 @@ const nextPost =
     >
       {title}
     </h1>
-    <div class="flex items-center gap-4">
-      <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" class="my-2" />
+    <div class="flex items-center gap-4 mt-2 mb-6">
+      <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
       <EditPost class="max-sm:hidden" {hideEditPost} {post} />
     </div>
-    <article id="article" class="mx-auto prose mt-8 max-w-3xl">
+    <article id="article" class="mx-auto prose mt-6 max-w-3xl">
       <Content />
     </article>
 


### PR DESCRIPTION
## Summary
- Fix calendar icon and text alignment in date fields
- Improve spacing consistency and visual balance around date components
- Remove CSS transform scaling in favor of proper size classes

## Changes Made
### Datetime Component
- Changed from `items-end` to `items-center` for proper icon-text alignment
- Replaced `space-x-2` with `gap-2` for more consistent spacing
- Removed `scale-90` transform and used proper `size-4`/`size-5` classes for cleaner icon sizing

### PostDetails Layout  
- Adjusted margins around date field for better visual balance
- Reduced spacing between title/date and content for more cohesive layout
- Moved margin classes from component to container for better control

## Problem Solved
The date field had alignment issues where:
- Calendar icon wasn't perfectly aligned with text baseline
- Small gap existed between icon and text
- Bottom margin was slightly larger than top margin
- Icon scaling caused alignment artifacts

## Test plan
- [x] Verify calendar icon aligns perfectly with date text
- [x] Check spacing consistency on mobile and desktop
- [x] Confirm visual balance between title, date, and content sections

🤖 Generated with [Claude Code](https://claude.ai/code)