### PR TITLE
Fix duplicate newsletter form on About page

### DIFF
--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -2,7 +2,6 @@
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import Layout from "./Layout.astro";
-import NewsletterForm from "@/components/NewsletterForm.astro";
 import { SITE } from "@/config";
 
 export interface Props {
@@ -22,11 +21,6 @@ const { frontmatter } = Astro.props;
       <h1 class="text-2xl tracking-wider sm:text-3xl">{frontmatter.title}</h1>
       <slot />
     </section>
-    
-    <div class="mb-12">
-      <h2 class="text-xl font-semibold mb-4">Stay Connected</h2>
-      <NewsletterForm variant="compact" />
-    </div>
   </main>
   <Footer />
 </Layout>

--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -40,4 +40,4 @@ If you'd like to connect or have questions about my work, feel free to reach out
   <NewsletterForm />
 </div>
 
-<p class="text-sm text-gray-500 mt-8">Imprint: Peter Steinberger, Siebensterngasse 15, 1070 Vienna, Austria</p>
+<p class="text-sm text-gray-400 dark:text-gray-600 mt-8">Imprint: Peter Steinberger, Siebensterngasse 15, 1070 Vienna, Austria</p>


### PR DESCRIPTION
## Summary
- Remove duplicate newsletter form from About page
- Reduce contrast of imprint text for better visual hierarchy

## Problem
The About page was showing two newsletter forms - one from the AboutLayout and another from the about.mdx content itself.

## Solution
- Removed the duplicate "Stay Connected" section and newsletter form from AboutLayout.astro
- Removed unused NewsletterForm import
- Changed imprint text color from `text-gray-500` to `text-gray-400 dark:text-gray-600` for less contrast

## Screenshot
The About page now shows only one newsletter form with proper spacing and hierarchy.

🤖 Generated with [Claude Code](https://claude.ai/code)