### PR TITLE
Improve share links sizing and spacing on mobile

### DIFF
--- a/src/components/ShareLinks.astro
+++ b/src/components/ShareLinks.astro
@@ -25,21 +25,21 @@ const iconMap = {
 ---
 
 <div
-  class="flex flex-col flex-wrap items-center justify-center gap-1 sm:items-start"
+  class="flex flex-col flex-wrap items-center justify-center gap-2 sm:gap-1 sm:items-start"
 >
   <span class="italic">Share this post on:</span>
-  <div class="text-center">
+  <div class="text-center flex flex-wrap gap-1">
     {
       SHARE_LINKS.map((social) => {
         const IconComponent = iconMap[social.icon as keyof typeof iconMap];
         return (
           <LinkButton
             href={`${social.href + URL}`}
-            class="p-2 hover:rotate-6"
+            class="p-3 sm:p-2 hover:rotate-6"
             title={social.linkTitle}
           >
             {IconComponent && (
-              <IconComponent class="inline-block size-7 sm:size-6 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent" />
+              <IconComponent class="inline-block size-8 sm:size-6 fill-transparent stroke-current stroke-2 opacity-90 group-hover:fill-transparent" />
             )}
             <span class="sr-only">{social.linkTitle}</span>
           </LinkButton>


### PR DESCRIPTION
## Summary

This PR improves the share links component to be more touch-friendly on mobile devices.

## Changes

- **Larger icons on mobile**: Increased from `size-7` to `size-8` (desktop remains `size-6`)
- **Better touch targets**: Increased padding from `p-2` to `p-3` on mobile
- **Improved spacing**: Added gap between share link buttons
- **Better visual hierarchy**: Increased gap between "Share this post on:" label and icons on mobile

## Why these changes?

Mobile touch targets should be at least 44x44 pixels according to Apple's Human Interface Guidelines and 48x48 according to Material Design. The previous implementation had smaller touch targets that could be difficult to tap accurately on mobile devices.

## Visual Impact

- Share links are now easier to tap on mobile devices
- Better spacing prevents accidental taps on adjacent links
- Maintains the compact design on desktop while improving mobile UX

🤖 Generated with [Claude Code](https://claude.ai/code)