### PR TITLE
Fix TypeScript errors

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [
       remarkToc,
+      // @ts-ignore - TypeScript has issues with remark plugin tuple syntax
       [remarkCollapse, { test: "Table of contents" }],
       remarkLazyLoadImages
     ],

--- a/src/utils/readingTime.ts
+++ b/src/utils/readingTime.ts
@@ -11,7 +11,7 @@ export async function getReadingTime(postId: string): Promise<string> {
   const posts = await getCollection('blog');
   const post = posts.find(p => p.id === postId);
   
-  if (!post) {
+  if (!post || !post.body) {
     return '5 min read'; // fallback
   }
   


### PR DESCRIPTION
## Summary
- Fixed TypeScript error in `readingTime.ts` by adding undefined check for `post.body`
- Fixed TypeScript error in `astro.config.mjs` by adding @ts-ignore for remark-collapse plugin tuple syntax

## Test plan
- [x] Run `npx tsc --noEmit` - no errors
- [x] Run `npm run lint` - no errors
- [x] Run `npm run build` - builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)