### PR TITLE
Fix duplicate author name in OG images

### DIFF
--- a/src/utils/og-templates/post.js
+++ b/src/utils/og-templates/post.js
@@ -1,6 +1,5 @@
 import satori from "satori";
 // import { html } from "satori-html";
-import { SITE } from "@/config";
 import loadGoogleFonts from "../loadGoogleFont";
 
 // const markup = html`<div
@@ -203,7 +202,7 @@ export default async (post) => {
                             type: "span",
                             props: {
                               style: { overflow: "hidden", fontWeight: "bold" },
-                              children: SITE.title,
+                              children: "steipete.me",
                             },
                           },
                         ],
@@ -222,7 +221,7 @@ export default async (post) => {
       height: 630,
       embedFont: true,
       fonts: await loadGoogleFonts(
-        post.data.title + post.data.author + SITE.title + "by",
+        post.data.title + post.data.author + "steipete.me" + "by",
       ),
     },
   );


### PR DESCRIPTION
## Summary
- Replace the duplicate "Peter Steinberger" text on the right side of OG images with "steipete.me"
- This avoids redundancy and improves the visual design of social media cards

## Test plan
- [x] Build passes successfully
- [ ] Review the OG images to confirm "steipete.me" appears on the right side

🤖 Generated with [Claude Code](https://claude.ai/code)