### PR TITLE
Remove border from Claude Code Army hero image

### DIFF
--- a/src/content/blog/2025/commanding-your-claude-code-army.md
+++ b/src/content/blog/2025/commanding-your-claude-code-army.md
@@ -71,3 +71,9 @@ When I run `cly`, my terminal title changes from `~/Projects/blog` to `📁 blog
 > *Hot tip: Just ask Claude to read this blog post and set it up for you! (in yolo mode, of course)*
 
 Now if you'll excuse me, I need to check on my Claude instances. I think one of them is refactoring my entire codebase without asking. Again.
+
+<style>
+  article img:first-of-type {
+    border: none !important;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Remove CSS border from hero image in "Commanding Your Claude Code Army" blog post
- Uses custom CSS targeting only this specific post

## Changes
- Added `<style>` block at the end of the blog post
- CSS removes border from first image in article (the hero image)
- Other posts retain their borders as intended

## Test Plan
- [ ] Hero image in Claude Code Army post has no border
- [ ] Other blog posts still show borders on their hero images
- [ ] No visual regressions in the post

🤖 Generated with [Claude Code](https://claude.ai/code)