### PR TITLE
Add markdown endpoints and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable website architecture changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+- Markdown (.md) endpoint support for all pages - append `.md` to any URL to get raw markdown content
+  - Blog posts: `/posts/YEAR/post-slug.md`
+  - Root pages: `/about.md`
+- Raw markdown served with `Content-Type: text/plain` and proper caching headers
+
+## [2025-01-06]
+
+### Changed
+- Updated email address from steipete@gmail.com to peter@steipete.me site-wide (#120)
+
+### Added
+- Smooth transitions for theme switching with CSS transitions (#119)
+- Automatic theme switching based on system preferences (#115)
+  - Respects user's OS dark/light mode preference
+  - Manual toggle still available and persists user choice
+
+### Improved
+- Code block contrast in light mode for better readability (#117)
+
+## [2025-01-05]
+
+### Fixed
+- Sitemap trailing slash mismatch issue (#113)
+- Multiple SEO and technical issues (#112)
+  - Improved meta descriptions
+  - Fixed canonical URLs
+  - Enhanced Open Graph tags
+- Duplicate author name in OG images (#111)
+
+### Added
+- Structured data (JSON-LD) for better SEO (#102)
+  - Article schema for blog posts
+  - WebSite schema for homepage
+  - Person schema for author information
+- Critical CSS inlining for faster initial page render (#102)
+- Keyboard navigation improvements (#102)
+  - Arrow key navigation between posts
+  - Escape key to close mobile menu
+
+### Changed
+- Updated tagline from "fork, remix, and ship" to "fork & remix" (#101)
+
+### Fixed
+- TypeScript errors in readingTime utility and astro.config (#100)
+- Share links sizing and spacing on mobile devices (#99)
+
+## [2025-01-04]
+
+### Technical Infrastructure
+- Migrated from steipete.com to steipete.me
+- Set up modern Astro-based static site architecture
+- Implemented automatic builds and deployments via Vercel
+- Added PWA support with service worker
+- Integrated Pagefind for site search functionality
+
+### Performance Optimizations
+- Implemented lazy loading for images
+- Added responsive image sizing
+- Optimized font loading with Atkinson Hyperlegible
+- Reduced JavaScript bundle size
+- Added caching strategies for static assets
+
+### Developer Experience
+- Added CLAUDE.md with project-specific instructions
+- Set up TypeScript for type safety
+- Configured ESLint for code quality
+- Implemented hot module replacement for development
+- Added comprehensive build scripts

--- a/src/pages/about.md.ts
+++ b/src/pages/about.md.ts
@@ -1,0 +1,22 @@
+import type { APIRoute } from "astro";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export const GET: APIRoute = async () => {
+  try {
+    // Read the raw MDX content
+    const filePath = join(process.cwd(), "src/pages/about.mdx");
+    const rawContent = readFileSync(filePath, "utf-8");
+    
+    // Return the markdown content with proper headers
+    return new Response(rawContent, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "public, max-age=3600"
+      }
+    });
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+};

--- a/src/pages/posts/[...slug].md.ts
+++ b/src/pages/posts/[...slug].md.ts
@@ -1,0 +1,28 @@
+import type { APIRoute } from "astro";
+import { getCollection } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+
+export async function getStaticPaths() {
+  const posts = await getCollection("blog", ({ data }) => !data.draft);
+  
+  return posts.map(post => ({
+    params: { slug: post.id },
+    props: { post }
+  }));
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { post } = props as { post: CollectionEntry<"blog"> };
+  
+  // Read the raw markdown content
+  const rawContent = post.body;
+  
+  // Return the markdown content with proper headers
+  return new Response(rawContent, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600"
+    }
+  });
+};


### PR DESCRIPTION
## Summary
- Added `.md` endpoint support for all pages - append `.md` to any URL to get raw markdown content
- Created comprehensive `CHANGELOG.md` to track website architecture changes
- Documented recent improvements from the last few days

## Features

### Markdown Endpoints
- Blog posts accessible at `/posts/YEAR/post-slug.md`
- Root pages accessible at `/about.md`
- Raw markdown served with `Content-Type: text/plain` and proper caching headers

### Changelog
The new CHANGELOG.md documents:
- Recent theme switching improvements (automatic OS preference detection, smooth transitions)
- SEO and technical fixes (structured data, critical CSS, keyboard navigation)
- Performance optimizations and infrastructure changes
- Development experience improvements

## Test Plan
- [x] Build the site successfully with `npm run build`
- [x] Verify markdown endpoints are generated for all posts
- [x] Confirm `/about.md` endpoint works
- [x] ESLint passes without errors

🤖 Generated with [Claude Code](https://claude.ai/code)