### PR TITLE
Add swift test --filter information to Swift Testing article

### DIFF
--- a/src/content/blog/2025/migrating-700-tests-to-swift-testing.md
+++ b/src/content/blog/2025/migrating-700-tests-to-swift-testing.md
@@ -475,6 +475,28 @@ There's also the [Context 7 MCP](https://context7.com/swiftlang/swift-testing) t
 
 The combination of AI assistance and systematic refinement made this large-scale migration manageable. While the initial AI conversion provided a foundation, the real value came from applying Swift Testing's features thoughtfully to create a more maintainable test suite.
 
+## Running Tests Faster with Filters
+
+One more tip that significantly speeds up the development workflow: use `swift test --filter` to run specific tests instead of the entire suite. This is especially useful when you're iterating on a particular feature:
+
+```bash
+# Run a single test suite by name
+swift test --filter "FooTests"
+
+# Run tests with specific tags
+swift test --filter-tag fast
+swift test --filter-tag currency
+
+# Combine multiple tags (runs tests with ALL specified tags)
+swift test --filter-tag unit --filter-tag fast
+
+# Skip tests with certain tags
+swift test --skip-tag slow
+swift test --skip-tag requiresNetwork
+```
+
+The performance difference is dramatic when working on a large codebase. Instead of waiting for 700+ tests to run, you can get feedback in seconds by filtering to just the tests you're working on. Combined with Swift Testing's parallel execution, this makes the test-driven development cycle incredibly fast.
+
 ---
 
 **P.S.** - If you're still manually converting `XCTestExpectation`, stop. [Make AI do it](claude-code-is-my-computer). Just give it [better instructions](https://gist.github.com/steipete/84a5952c22e1ff9b6fe274ab079e3a95) than I did.


### PR DESCRIPTION
## Summary
Added information about using `swift test --filter` to run specific tests, addressing reader feedback about this missing feature.

## Changes
Added a new section "Running Tests Faster with Filters" that explains:
- How to filter tests by suite name (e.g., `swift test --filter "FooTests"`)
- How to use tag-based filtering with `--filter-tag` and `--skip-tag`
- Examples of combining multiple filters
- The performance benefits of filtering when working with large test suites

This addresses the feedback: "PS: I feel the info is missing that swift test can use —filter "FooTests" to only test a single file, that's much faster."

## Test plan
- [x] Build passes locally
- [x] Article renders correctly with new section
- [x] Code examples are properly formatted

🤖 Generated with [Claude Code](https://claude.ai/code)