### PR TITLE
Add steipete.md domain support for markdown-only content

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,28 @@
 export const onRequest = async (context, next) => {
   const url = new URL(context.request.url);
+  const hostname = context.request.headers.get('host');
+
+  // Handle steipete.md domain - serve markdown versions
+  if (hostname === 'steipete.md' || hostname === 'www.steipete.md') {
+    // Don't add .md if it's already there
+    if (!url.pathname.endsWith('.md')) {
+      // Special handling for root path
+      if (url.pathname === '/' || url.pathname === '') {
+        // Rewrite to index.md
+        return context.rewrite('/index.md');
+      }
+      
+      // For all other paths, append .md
+      const mdPath = url.pathname + '.md';
+      
+      // Create a new URL with the .md extension
+      const newUrl = new URL(context.request.url);
+      newUrl.pathname = mdPath;
+      
+      // Rewrite the request to the .md version
+      return context.rewrite(newUrl.toString());
+    }
+  }
 
   // Redirect /blog/ paths to /posts/
   if (url.pathname.startsWith("/blog/")) {

--- a/src/pages/archives.md.ts
+++ b/src/pages/archives.md.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import getSortedPosts from '@/utils/getSortedPosts';
+
+export const GET: APIRoute = async () => {
+  const posts = await getCollection('blog');
+  const sortedPosts = getSortedPosts(posts);
+  
+  let markdownContent = `# Archives\n\n`;
+  markdownContent += `Total posts: ${sortedPosts.length}\n\n`;
+  
+  // Group posts by year
+  const postsByYear = sortedPosts.reduce((acc, post) => {
+    const year = post.data.pubDatetime.getFullYear();
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(post);
+    return acc;
+  }, {} as Record<number, typeof sortedPosts>);
+  
+  // Sort years descending
+  const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+  
+  markdownContent += `## Posts by Year\n\n`;
+  
+  for (const year of years) {
+    const count = postsByYear[Number(year)].length;
+    markdownContent += `- [${year}](/posts.md#${year}) (${count} post${count !== 1 ? 's' : ''})\n`;
+  }
+  
+  markdownContent += `\n---\n\n[Back to Home](/index.md) | [All Posts](/posts.md)`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async () => {
+  const markdownContent = `# Peter Steinberger (@steipete)
+
+AI-powered tools from Swift roots to web frontiers. Every commit lands on GitHub for you to fork & remix.
+
+## Navigation
+
+- [About](/about.md)
+- [Recent Posts](/posts.md)
+- [Archives](/archives.md)
+- [RSS Feed](/rss.xml)
+
+## Links
+
+- Twitter: [@steipete](https://twitter.com/steipete)
+- GitHub: [@steipete](https://github.com/steipete)
+- Email: steipete@gmail.com
+
+---
+
+*This is the markdown-only version of steipete.me. Visit [steipete.me](https://steipete.me) for the full experience.*`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/posts.md.ts
+++ b/src/pages/posts.md.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import getSortedPosts from '@/utils/getSortedPosts';
+
+export const GET: APIRoute = async () => {
+  const posts = await getCollection('blog');
+  const sortedPosts = getSortedPosts(posts);
+  
+  let markdownContent = `# All Posts\n\n`;
+  
+  // Group posts by year
+  const postsByYear = sortedPosts.reduce((acc, post) => {
+    const year = post.data.pubDatetime.getFullYear();
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(post);
+    return acc;
+  }, {} as Record<number, typeof sortedPosts>);
+  
+  // Sort years descending
+  const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+  
+  for (const year of years) {
+    markdownContent += `## ${year}\n\n`;
+    
+    for (const post of postsByYear[Number(year)]) {
+      const date = post.data.pubDatetime.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+      markdownContent += `- ${date}: [${post.data.title}](/posts/${post.slug}.md)\n`;
+    }
+    
+    markdownContent += '\n';
+  }
+  
+  markdownContent += `---\n\n[Back to Home](/index.md)`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- Add middleware logic to serve markdown content when accessing via steipete.md domain
- Create new markdown endpoints for better navigation (index.md, posts.md, archives.md)
- All paths on steipete.md automatically append .md extension for markdown viewing

## How it works

When users visit `steipete.md`:
1. The middleware detects the domain
2. For the root path `/`, it serves `/index.md` with a simple markdown homepage
3. For all other paths, it appends `.md` to serve the markdown version
4. Existing `.md` endpoints continue to work as before

This allows the entire site to be browsed in markdown format by using the steipete.md domain instead of steipete.me.

## Test plan
- [ ] Access steipete.md and verify it shows the markdown homepage
- [ ] Navigate to steipete.md/about and verify it shows the about page in markdown
- [ ] Navigate to steipete.md/posts/[any-post] and verify blog posts render as markdown
- [ ] Verify steipete.me continues to work normally

🤖 Generated with [Claude Code](https://claude.ai/code)