### PR TITLE
Fix vercel.json to allow steipete.md domain

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,28 @@
 export const onRequest = async (context, next) => {
   const url = new URL(context.request.url);
+  const hostname = context.request.headers.get('host');
+
+  // Handle steipete.md domain - serve markdown versions
+  if (hostname === 'steipete.md' || hostname === 'www.steipete.md') {
+    // Don't add .md if it's already there
+    if (!url.pathname.endsWith('.md')) {
+      // Special handling for root path
+      if (url.pathname === '/' || url.pathname === '') {
+        // Rewrite to index.md
+        return context.rewrite('/index.md');
+      }
+      
+      // For all other paths, append .md
+      const mdPath = url.pathname + '.md';
+      
+      // Create a new URL with the .md extension
+      const newUrl = new URL(context.request.url);
+      newUrl.pathname = mdPath;
+      
+      // Rewrite the request to the .md version
+      return context.rewrite(newUrl.toString());
+    }
+  }
 
   // Redirect /blog/ paths to /posts/
   if (url.pathname.startsWith("/blog/")) {

--- a/src/pages/archives.md.ts
+++ b/src/pages/archives.md.ts
@@ -1,0 +1,39 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import getSortedPosts from '@/utils/getSortedPosts';
+
+export const GET: APIRoute = async () => {
+  const posts = await getCollection('blog');
+  const sortedPosts = getSortedPosts(posts);
+  
+  let markdownContent = `# Archives\n\n`;
+  markdownContent += `Total posts: ${sortedPosts.length}\n\n`;
+  
+  // Group posts by year
+  const postsByYear = sortedPosts.reduce((acc, post) => {
+    const year = post.data.pubDatetime.getFullYear();
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(post);
+    return acc;
+  }, {} as Record<number, typeof sortedPosts>);
+  
+  // Sort years descending
+  const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+  
+  markdownContent += `## Posts by Year\n\n`;
+  
+  for (const year of years) {
+    const count = postsByYear[Number(year)].length;
+    markdownContent += `- [${year}](/posts.md#${year}) (${count} post${count !== 1 ? 's' : ''})\n`;
+  }
+  
+  markdownContent += `\n---\n\n[Back to Home](/index.md) | [All Posts](/posts.md)`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async () => {
+  const markdownContent = `# Peter Steinberger (@steipete)
+
+AI-powered tools from Swift roots to web frontiers. Every commit lands on GitHub for you to fork & remix.
+
+## Navigation
+
+- [About](/about.md)
+- [Recent Posts](/posts.md)
+- [Archives](/archives.md)
+- [RSS Feed](/rss.xml)
+
+## Links
+
+- Twitter: [@steipete](https://twitter.com/steipete)
+- GitHub: [@steipete](https://github.com/steipete)
+- Email: steipete@gmail.com
+
+---
+
+*This is the markdown-only version of steipete.me. Visit [steipete.me](https://steipete.me) for the full experience.*`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/src/pages/posts.md.ts
+++ b/src/pages/posts.md.ts
@@ -1,0 +1,45 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+import getSortedPosts from '@/utils/getSortedPosts';
+
+export const GET: APIRoute = async () => {
+  const posts = await getCollection('blog');
+  const sortedPosts = getSortedPosts(posts);
+  
+  let markdownContent = `# All Posts\n\n`;
+  
+  // Group posts by year
+  const postsByYear = sortedPosts.reduce((acc, post) => {
+    const year = post.data.pubDatetime.getFullYear();
+    if (!acc[year]) acc[year] = [];
+    acc[year].push(post);
+    return acc;
+  }, {} as Record<number, typeof sortedPosts>);
+  
+  // Sort years descending
+  const years = Object.keys(postsByYear).sort((a, b) => Number(b) - Number(a));
+  
+  for (const year of years) {
+    markdownContent += `## ${year}\n\n`;
+    
+    for (const post of postsByYear[Number(year)]) {
+      const date = post.data.pubDatetime.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
+      markdownContent += `- ${date}: [${post.data.title}](/posts/${post.slug}.md)\n`;
+    }
+    
+    markdownContent += '\n';
+  }
+  
+  markdownContent += `---\n\n[Back to Home](/index.md)`;
+
+  return new Response(markdownContent, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+};

--- a/vercel.json
+++ b/vercel.json
@@ -39,7 +39,7 @@
     },
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "^(?!steipete\\.me|.*\\.vercel\\.app|.*\\.friendship\\.dev|.*\\.amantus\\.dev).*$" }],
+      "has": [{ "type": "host", "value": "^(?!steipete\\.me|steipete\\.md|.*\\.vercel\\.app|.*\\.friendship\\.dev|.*\\.amantus\\.dev).*$" }],
       "destination": "https://steipete.me/:path*",
       "permanent": true
     }


### PR DESCRIPTION
## Summary
- Update vercel.json redirect rule to exclude steipete.md from being redirected to steipete.me

## Why this is needed
The previous PR added middleware to handle steipete.md, but the Vercel redirect rule was catching all non-primary domains and redirecting them to steipete.me before the middleware could run.

This fix adds `steipete\\.md` to the negative regex pattern so that requests to steipete.md are not redirected and can be handled by the middleware.

## Test plan
- [ ] Deploy to Vercel and verify steipete.md doesn't redirect to steipete.me
- [ ] Verify steipete.md shows the markdown version of the site
- [ ] Verify other domains still redirect to steipete.me as expected

🤖 Generated with [Claude Code](https://claude.ai/code)