### PR TITLE
Update steipete.md handling: redirect .md URLs and support year-based paths

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,28 +1,5 @@
 export const onRequest = async (context, next) => {
   const url = new URL(context.request.url);
-  const hostname = context.request.headers.get('host');
-
-  // Handle steipete.md domain - serve markdown versions
-  if (hostname === 'steipete.md' || hostname === 'www.steipete.md') {
-    // Don't add .md if it's already there
-    if (!url.pathname.endsWith('.md')) {
-      // Special handling for root path
-      if (url.pathname === '/' || url.pathname === '') {
-        // Rewrite to index.md
-        return context.rewrite('/index.md');
-      }
-      
-      // For all other paths, append .md
-      const mdPath = url.pathname + '.md';
-      
-      // Create a new URL with the .md extension
-      const newUrl = new URL(context.request.url);
-      newUrl.pathname = mdPath;
-      
-      // Rewrite the request to the .md version
-      return context.rewrite(newUrl.toString());
-    }
-  }
 
   // Redirect /blog/ paths to /posts/
   if (url.pathname.startsWith("/blog/")) {

--- a/vercel.json
+++ b/vercel.json
@@ -44,7 +44,33 @@
       "permanent": true
     }
   ],
-  "rewrites": [],
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [{ "type": "host", "value": "steipete.md" }],
+      "destination": "/index.md"
+    },
+    {
+      "source": "/about",
+      "has": [{ "type": "host", "value": "steipete.md" }],
+      "destination": "/about.md"
+    },
+    {
+      "source": "/posts",
+      "has": [{ "type": "host", "value": "steipete.md" }],
+      "destination": "/posts.md"
+    },
+    {
+      "source": "/archives",
+      "has": [{ "type": "host", "value": "steipete.md" }],
+      "destination": "/archives.md"
+    },
+    {
+      "source": "/posts/:slug",
+      "has": [{ "type": "host", "value": "steipete.md" }],
+      "destination": "/posts/:slug.md"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,12 @@
   "trailingSlash": false,
   "redirects": [
     {
+      "source": "/:path*.md",
+      "has": [{ "type": "host", "value": "steipete.me" }],
+      "destination": "https://steipete.md/:path*",
+      "permanent": false
+    },
+    {
       "source": "/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug",
       "destination": "/posts/:slug",
       "permanent": true
@@ -64,6 +70,11 @@
       "source": "/archives",
       "has": [{ "type": "host", "value": "steipete.md" }],
       "destination": "/archives.md"
+    },
+    {
+      "source": "/posts/:year/:slug",
+      "has": [{ "type": "host", "value": "steipete.md" }],
+      "destination": "/posts/:year/:slug.md"
     },
     {
       "source": "/posts/:slug",


### PR DESCRIPTION
## Summary
- Add redirect from `steipete.me/*.md` to `steipete.md/*`
- Support year-based blog post paths (`/posts/2025/slug`)
- Keep existing rewrites for steipete.md domain

## What this enables

1. **Regular website on steipete.me:**
   - `https://steipete.me/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents`

2. **Markdown version on steipete.md:**
   - `https://steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents`

3. **Redirect .md extension to markdown domain:**
   - `https://steipete.me/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents.md`
   - → redirects to `https://steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents`

## Changes made
- Added a redirect rule that catches any `.md` URL on steipete.me and redirects to steipete.md
- Added rewrite rule for year-based paths (`/posts/:year/:slug`)
- Redirect is non-permanent (302) for flexibility

## Test plan
- [ ] Deploy to Vercel
- [ ] Test regular website: `steipete.me/posts/2025/[any-post]`
- [ ] Test markdown version: `steipete.md/posts/2025/[any-post]`
- [ ] Test .md redirect: `steipete.me/posts/2025/[any-post].md` → should redirect to `steipete.md/posts/2025/[any-post]`
- [ ] Test other pages still work (about, archives, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)