### PR TITLE
Fix steipete.md redirect loop issue

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -45,7 +45,7 @@
     },
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "^(?!steipete\\.me|steipete\\.md|.*\\.vercel\\.app|.*\\.friendship\\.dev|.*\\.amantus\\.dev).*$" }],
+      "has": [{ "type": "host", "value": "^(?!(steipete\\.me|www\\.steipete\\.me|steipete\\.md|www\\.steipete\\.md|.*\\.vercel\\.app|.*\\.friendship\\.dev|.*\\.amantus\\.dev)).*$" }],
       "destination": "https://steipete.me/:path*",
       "permanent": true
     }
@@ -53,32 +53,32 @@
   "rewrites": [
     {
       "source": "/",
-      "has": [{ "type": "host", "value": "steipete.md" }],
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
       "destination": "/index.md"
     },
     {
       "source": "/about",
-      "has": [{ "type": "host", "value": "steipete.md" }],
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
       "destination": "/about.md"
     },
     {
       "source": "/posts",
-      "has": [{ "type": "host", "value": "steipete.md" }],
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
       "destination": "/posts.md"
     },
     {
       "source": "/archives",
-      "has": [{ "type": "host", "value": "steipete.md" }],
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
       "destination": "/archives.md"
     },
     {
       "source": "/posts/:year/:slug",
-      "has": [{ "type": "host", "value": "steipete.md" }],
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
       "destination": "/posts/:year/:slug.md"
     },
     {
       "source": "/posts/:slug",
-      "has": [{ "type": "host", "value": "steipete.md" }],
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
       "destination": "/posts/:slug.md"
     }
   ],


### PR DESCRIPTION
## Summary
- Fixed the catch-all redirect regex to properly exclude steipete.md domain
- Added support for www variants in both redirects and rewrites
- Fixed regex pattern to use proper grouping for negative lookahead

## Problem
When visiting `steipete.md/about`, it was being redirected to `steipete.me/about` instead of showing the markdown version. This was because the catch-all redirect rule was matching steipete.md and redirecting it back to steipete.me.

## Solution
1. Updated the negative lookahead regex to properly exclude steipete.md (with proper grouping)
2. Added www variants to ensure both `steipete.md` and `www.steipete.md` work correctly
3. Updated all rewrite rules to use regex patterns that match both www and non-www variants

## Test plan
- [ ] Deploy to Vercel
- [ ] Visit `steipete.md/about` - should show markdown version (not redirect)
- [ ] Visit `steipete.me/about` - should show regular HTML website
- [ ] Visit `steipete.me/about.md` - should redirect to `steipete.md/about`
- [ ] Test with www variants as well

🤖 Generated with [Claude Code](https://claude.ai/code)