### PR TITLE
Simplify steipete.md rewrites to catch all paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -52,34 +52,9 @@
   ],
   "rewrites": [
     {
-      "source": "/",
+      "source": "/:path((?!.*\\.md$).*)",
       "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/index.md"
-    },
-    {
-      "source": "/about",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/about.md"
-    },
-    {
-      "source": "/posts",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/posts.md"
-    },
-    {
-      "source": "/archives",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/archives.md"
-    },
-    {
-      "source": "/posts/:year/:slug",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/posts/:year/:slug.md"
-    },
-    {
-      "source": "/posts/:slug",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/posts/:slug.md"
+      "destination": "/:path.md"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Replace multiple specific rewrite rules with a single catch-all rule
- Use negative lookahead regex to prevent double .md extensions

## Problem
The previous rewrite rules were too specific and missed paths like:
- `/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents`

This caused steipete.md to serve the regular HTML website instead of markdown.

## Solution
Use a single catch-all rewrite rule:
```json
{
  "source": "/:path((?\!.*\\.md$).*)",
  "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
  "destination": "/:path.md"
}
```

This pattern:
- Matches all paths that don't already end in `.md`
- Appends `.md` to the destination
- Works for all current and future paths automatically

## Test plan
- [ ] Deploy to Vercel
- [ ] Test `steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents` shows markdown
- [ ] Test `steipete.md/about` shows markdown
- [ ] Test `steipete.md/` shows markdown homepage
- [ ] Verify paths already ending in .md don't get double extensions

🤖 Generated with [Claude Code](https://claude.ai/code)