### PR TITLE
Fix steipete.md rewrite pattern to handle all paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -52,9 +52,14 @@
   ],
   "rewrites": [
     {
-      "source": "/:path((?!.*\\.md$).*)",
+      "source": "/",
       "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/:path.md"
+      "destination": "/index.md"
+    },
+    {
+      "source": "/:path+",
+      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
+      "destination": "/:path+.md"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Update rewrite rules to properly handle all paths on steipete.md
- Use :path+ pattern for better path matching

## Problem
The current rewrite rules are not catching paths like:
`/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents`

This causes steipete.md to serve the regular HTML website instead of markdown.

## Solution
Split the rewrites into two simple rules:
1. `/` → `/index.md` for the root
2. `/:path+` → `/:path+.md` for all other paths

The `:path+` pattern matches one or more path segments, properly handling nested paths.

## Test plan
- [ ] Deploy to Vercel
- [ ] Test `steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents` shows markdown
- [ ] Test `steipete.md/about` shows markdown
- [ ] Test `steipete.md/` shows markdown homepage
- [ ] Test `www.steipete.md` variants work the same way

🤖 Generated with [Claude Code](https://claude.ai/code)