### PR TITLE
Fix steipete.md rewrite pattern to handle all paths

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -57,9 +57,9 @@
       "destination": "/index.md"
     },
     {
-      "source": "/:path+",
+      "source": "/:path((?!.*\\.md$).*)",
       "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/:path+.md"
+      "destination": "/:path.md"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Update rewrite rules to properly handle all paths on steipete.md
- Use negative lookahead pattern to prevent double .md extensions

## Problem
The current rewrite rules are not catching paths like:
`/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents`

This causes steipete.md to serve the regular HTML website instead of markdown.

## Solution
Use proper Vercel rewrite patterns:
1. `/` → `/index.md` for the root
2. `/:path((?\!.*\.md$).*)` → `/:path.md` for all other paths

The negative lookahead pattern `(?\!.*\.md$)` ensures we don't double-append .md to paths already ending in .md.

## Test plan
- [ ] Deploy to Vercel
- [ ] Test `steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents` shows markdown
- [ ] Test `steipete.md/about` shows markdown
- [ ] Test `steipete.md/` shows markdown homepage
- [ ] Test `www.steipete.md` variants work the same way
- [ ] Verify paths already ending in .md don't get double extensions

🤖 Generated with [Claude Code](https://claude.ai/code)