### PR TITLE
Fix steipete.md serving HTML instead of markdown

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -53,13 +53,13 @@
   "rewrites": [
     {
       "source": "/",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
+      "has": [{ "type": "host", "value": "(www\\.)?steipete\\.md" }],
       "destination": "/index.md"
     },
     {
-      "source": "/:path+",
-      "has": [{ "type": "host", "value": "^(www\\.)?steipete\\.md$" }],
-      "destination": "/:path+.md"
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "(www\\.)?steipete\\.md" }],
+      "destination": "/:path*.md"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Simplify the host pattern in rewrite rules
- Remove complex regex that might be preventing rewrites from working

## Problem
Currently https://www.steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents serves HTML instead of markdown.

The .md files exist (can be accessed directly), but the rewrites aren't working.

## Solution
Simplified the host pattern from `^(www\\.)?steipete\\.md$` to `(www\\.)?steipete\\.md`

The complex regex pattern might be causing Vercel to not match the host properly.

## Test plan
- [ ] Deploy to Vercel
- [ ] Test `steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents` shows markdown
- [ ] Test `www.steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents` shows markdown
- [ ] Verify the .md files are actually being served as markdown, not HTML

🤖 Generated with [Claude Code](https://claude.ai/code)