### PR TITLE
Add client-side redirect for steipete.md to serve markdown

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -131,6 +131,17 @@ const structuredData = {
 
     <script is:inline src="/toggle-theme.js"></script>
     
+    <!-- Domain-based markdown redirect -->
+    <script is:inline>
+      // Check if we're on steipete.md domain
+      const hostname = window.location.hostname;
+      if ((hostname === 'steipete.md' || hostname === 'www.steipete.md') && !window.location.pathname.endsWith('.md')) {
+        // Redirect to the .md version of the current page
+        const mdPath = window.location.pathname === '/' ? '/index.md' : window.location.pathname + '.md';
+        window.location.replace(mdPath + window.location.search + window.location.hash);
+      }
+    </script>
+    
     <!-- Twitter Widget Script -->
     <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   </head>


### PR DESCRIPTION
## Summary
- Add JavaScript to detect steipete.md domain and redirect to .md versions
- Works around Vercel's limitations with domain-based rewrites for static sites

## Problem
Vercel's rewrite rules with domain-based conditions don't work properly for static sites. The `has` condition with `type: "host"` is not fully supported in vercel.json.

When visiting steipete.md, users see the HTML website instead of markdown.

## Solution
Implement a client-side redirect that:
1. Detects when the page loads on steipete.md or www.steipete.md
2. Redirects to the .md version of the current page
3. Handles the root path specially (/ → /index.md)

This runs in the browser after the page loads, ensuring markdown content is served for the steipete.md domain.

## Test plan
- [ ] Deploy to Vercel
- [ ] Visit `steipete.md` - should redirect to `/index.md`
- [ ] Visit `steipete.md/about` - should redirect to `/about.md`
- [ ] Visit `steipete.md/posts/2025/peekaboo-mcp-lightning-fast-macos-screenshots-for-ai-agents` - should redirect to the .md version
- [ ] Ensure steipete.me continues to work normally without redirects

🤖 Generated with [Claude Code](https://claude.ai/code)