### PR TITLE
Clean up steipete.md implementation and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- steipete.md domain support for markdown-only viewing (#130, #139)
+  - Visit steipete.md to automatically see markdown versions of all pages
+  - Client-side redirect handles domain detection and .md routing
+  - Works around Vercel's limitations with domain-based rewrites for static sites
 - Markdown (.md) endpoint support for all pages - append `.md` to any URL to get raw markdown content
   - Blog posts: `/posts/YEAR/post-slug.md`
   - Root pages: `/about.md`
 - Raw markdown served with `Content-Type: text/plain` and proper caching headers
+- Redirect from steipete.me/*.md URLs to steipete.md/* (#133)
 
 ### Fixed
 - Slow theme switching animation on iPhone Safari (#122)

--- a/vercel.json
+++ b/vercel.json
@@ -50,18 +50,7 @@
       "permanent": true
     }
   ],
-  "rewrites": [
-    {
-      "source": "/",
-      "has": [{ "type": "host", "value": "(www\\.)?steipete\\.md" }],
-      "destination": "/index.md"
-    },
-    {
-      "source": "/:path*",
-      "has": [{ "type": "host", "value": "(www\\.)?steipete\\.md" }],
-      "destination": "/:path*.md"
-    }
-  ],
+  "rewrites": [],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Remove non-functional Vercel rewrites from vercel.json
- Update CHANGELOG.md with complete steipete.md feature documentation

## What this PR does

### 1. Removes dead code
The Vercel rewrites with `has` conditions for domain-based routing don't work for static sites. These have been replaced by the client-side JavaScript redirect (PR #139), so the rewrite rules can be removed.

### 2. Updates CHANGELOG
Documents the complete steipete.md feature implementation:
- Domain support via client-side redirect
- References to relevant PRs (#130, #133, #139)
- Explanation that this works around Vercel's limitations

## Context
After multiple attempts to use Vercel's rewrite rules for domain-based routing, we discovered that the `has` condition with `type: "host"` is not fully supported for static sites in vercel.json. The client-side JavaScript redirect solution works reliably.

## Test plan
- [ ] Verify steipete.md still redirects to markdown versions
- [ ] Ensure no functionality is broken by removing the rewrites

🤖 Generated with [Claude Code](https://claude.ai/code)