### PR TITLE
Fix undefined links in posts.md and add tip to about page

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -41,6 +41,8 @@ I build what excites me and release it all as open source.
 
 If you'd like to connect or have questions about my work, feel free to reach out through any of the links below.
 
+Tip: Change steipete.me to steipete.md for the markdown version.
+
 <div class="not-prose">
   <p class="text-sm text-gray-500 dark:text-gray-400 mt-8">Imprint: Peter Steinberger, Siebensterngasse 15, 1070 Vienna, Austria</p>
 </div>

--- a/src/pages/posts.md.ts
+++ b/src/pages/posts.md.ts
@@ -27,7 +27,7 @@ export const GET: APIRoute = async () => {
         month: 'short',
         day: 'numeric',
       });
-      markdownContent += `- ${date}: [${post.data.title}](/posts/${post.slug}.md)\n`;
+      markdownContent += `- ${date}: [${post.data.title}](/posts/${post.id}.md)\n`;
     }
     
     markdownContent += '\n';


### PR DESCRIPTION
## Summary
- Fix undefined links in posts.md by using post.id instead of post.slug
- Add the missing tip about steipete.md to the about page

## Problem
When visiting https://www.steipete.md/posts.md, the links show as "undefined" because the URLs were missing the year component.

## Solution
- Changed from `post.slug` to `post.id` which includes the year path (e.g., "2025/post-slug")
- Also added back the tip about steipete.md that was missing from the merged PR

## Test plan
- [ ] Visit steipete.md/posts.md and verify links work correctly
- [ ] Check that links include the year (e.g., /posts/2025/claude-code-is-my-computer.md)
- [ ] Verify the tip appears on the about page

🤖 Generated with [Claude Code](https://claude.ai/code)