### PR TITLE
Add link to agent-rules repository

### DIFF
--- a/src/content/blog/2025/claude-code-is-my-computer.md
+++ b/src/content/blog/2025/claude-code-is-my-computer.md
@@ -51,7 +51,7 @@ I use an alias in my shell config[^2] so just typing `cc` runs Claude with the p
 
 Claude Code shines because it was built command-line-first, not bolted onto an IDE as an afterthought. The agent has full access to my filesystem (if you are bold enough...), can execute commands, read output, and iterate based on results.
 
-Anthropic's [best practices guide](https://www.anthropic.com/engineering/claude-code-best-practices) recommends keeping a `CLAUDE.md` file at your repo root with project-specific context. I've adopted this pattern and noticed Claude asks fewer clarifying questions and writes more accurate code. Little optimizations like this compound quickly.
+Anthropic's [best practices guide](https://www.anthropic.com/engineering/claude-code-best-practices) recommends keeping a `CLAUDE.md` file at your repo root with project-specific context. I've adopted this pattern and noticed Claude asks fewer clarifying questions and writes more accurate code. You can check out [my Claude Code rules](https://github.com/steipete/agent-rules) for examples of how I structure these files. Little optimizations like this compound quickly.
 
 The main limitation is response time. Claude's thinking process takes a few seconds, and for rapid-fire debugging sessions, I sometimes reach for traditional tools. However, you can prefix commands with `!` to run them directly without waiting for token evaluation—Claude will execute your command either way, but this is faster when you know exactly what you're calling. For exploratory work where I'm not sure what I need, Claude's reasoning ability more than compensates for the brief pause.
 


### PR DESCRIPTION
## Summary
- Added link to the agent-rules repository in the Claude Code blog post
- Positioned within the CLAUDE.md section for relevant context

## Changes
Added a link to https://github.com/steipete/agent-rules in the paragraph discussing CLAUDE.md files, providing readers with concrete examples of how to structure these configuration files.

## Test plan
- [x] Preview the blog post to ensure the link appears correctly
- [x] Verify the link flows naturally within the existing text

🤖 Generated with [Claude Code](https://claude.ai/code)