### PR TITLE
Add 'Beyond Just llm.codes' section break for better readability

### DIFF
--- a/src/content/blog/llm-codes-transform-developer-docs.md
+++ b/src/content/blog/llm-codes-transform-developer-docs.md
@@ -74,6 +74,8 @@ The key insight: When you work on a component, just ask Claude to read the docs.
 
 For people who think [@Context7](https://x.com/Context7AI) is the answer: if you use the context7 mcp for SwiftUI, you get sample code from 2019, which will produce horribly outdated code. You need current documentation, not ancient examples.
 
+## Beyond Just llm.codes
+
 I used this trick before in my post about [migrating 700 tests to Swift Testing](https://steipete.me/posts/2025/migrating-700-tests-to-swift-testing). With llm.codes, you get significantly smaller markdown files, which preserves more token context space for your agent.
 
 I also maintain a [collection of pre-converted Markdown documentation files](https://github.com/steipete/agent-rules/tree/main/docs) in my agent-rules repository, that go beyond just documentation.


### PR DESCRIPTION
Breaks up the long Real-World Example section to improve readability.

## Changes
- Adds a new heading '## Beyond Just llm.codes' after the Context7 paragraph
- Creates a natural division between:
  - Problem explanation (toolbar issue, key insight, Context7 comparison)
  - Additional resources and solutions (previous usage, agent-rules repo, build details)
- Improves visual hierarchy and makes the content easier to scan

This follows Option 3 from the suggested approaches, creating a logical break between explaining the problem and showing multiple solutions/resources.