### PR TITLE
Add unlisted flag to VibeTunnel blog post

### DIFF
--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -2,6 +2,7 @@
 title: "VibeTunnel: Turn Any Browser into Your Mac's Terminal"
 pubDatetime: 2025-06-16T12:00:00.000+01:00
 description: "How we built VibeTunnel in a marathon coding session - a browser-based terminal that uses named pipes, XtermJS, and Claude Code to give you shell access from anywhere."
+unlisted: true
 tags:
   - Terminal
   - Web Development


### PR DESCRIPTION
## Summary
- Added `unlisted: true` flag to the VibeTunnel blog post frontmatter to allow publishing without linking from the main blog index

## Context
This change was separated from the previous PR that was merged too quickly. The unlisted flag allows the post to be accessible via direct link while keeping it hidden from the main blog listing.