### PR TITLE
Fix typos and grammar issues in VibeTunnel blog post

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -47,7 +47,7 @@ Mario spent two hours going down a rabbit hole, investigating whether to write h
 
 Mario explained:
 
-> I first investigated whether I can write my own ANSI sequence renderer. That kinda worked. But there were so many edge cases that I eventually searched for something else. Armin had been recommending [Xterm.js](https://xtermjs.org) all along.
+> I first investigated whether I could write my own ANSI sequence renderer. That kinda worked. But there were so many edge cases that I eventually searched for something else. Armin had been recommending [Xterm.js](https://xtermjs.org) all along.
 
 > I went through that a bit and thought maybe I can figure that out, but there was no way to get that working. So I went back to Xterm and spent about two hours figuring out how it works and how to massage it so it works in our context as well.
 
@@ -73,11 +73,11 @@ The solution? Multiplexing. Instead of one connection per terminal, we need a si
 
 Armin put it in perspective:
 
-> 20x is not an understatement in terms of how much faster we are with agents. As an Example: This button that I added to the UI, which is install the shell command and sudo the user. It wrote shell script. It wrote an Apple script. And then it wrote another thing around it, and it took it two and a half minutes. And for me to figure out how to bring up the right sudo dialogue, which kind of workaround to use to bring this thing in would have been two hours, three hours.
+> 20x is not an understatement in terms of how much faster we are with agents. As an example: This button that I added to the UI, which is install the shell command and sudo the user. It wrote shell script. It wrote an Apple script. And then it wrote another thing around it, and it took it two and a half minutes. And for me to figure out how to bring up the right sudo dialogue, which kind of workaround to use to bring this thing in would have been two hours, three hours.
 
 He compared it to his experience at [Sentry](https://sentry.io):
 
-> We every year, we had a hack week culture. So every year, we took four days to five days of three to four people working on one project. And, honestly, three, four people working for five days not nearly as impressive in terms of how much stuff you can produce than I think even within twelve hours.
+> Every year, we had a hack week culture. So every year, we took four days to five days of three to four people working on one project. And, honestly, three, four people working for five days not nearly as impressive in terms of how much stuff you can produce than I think even within twelve hours.
 
 Claude excels at bootstrapping. Need to integrate a library you've never used? Claude will get you 80% there in minutes. Want to understand how Server-Sent Events work? Claude generates a working example faster than you can read the MDN docs. 
 

--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -41,7 +41,7 @@ Within hours, we had transformed it into a full bidirectional terminal emulator.
 
 ### From Asciinema to Xterm.js: The Midnight Pivot
 
-Our first major challenge came after midnight when we needed a proper [scrollback buffer](https://unix.stackexchange.com/questions/145050/what-exactly-is-scrollback-and-scrollback-buffer). The initial asciinema approach had a fatal flaw - no history. You couldn't scroll back to see previous output, making it useless for any real work. Imagine running a build command and not being able to scroll up to see the errors!
+Our first major challenge came after midnight when we needed a proper [scrollback buffer](https://unix.stackexchange.com/questions/145050/what-exactly-is-scrollback-and-scrollback-buffer). The initial asciinema approach had a fatal flaw - no history. You couldn't scrollback to see previous output, making it useless for any real work. Imagine running a build command and not being able to scroll up to see the errors!
 
 Mario spent two hours going down a rabbit hole, investigating whether to write his own ANSI sequence renderer. He got surprisingly far - basic text output worked, colors were rendering, cursor movement was... sort of working. But then came the edge cases: double-width characters, complex cursor positioning, alternate screen buffers, and the hundreds of other ANSI escape sequences that real terminals support. It was becoming clear this was a month-long project, not a two-hour hack.
 


### PR DESCRIPTION
## Summary
Fixed multiple typos and grammar issues found in the VibeTunnel blog post.

## Changes
1. **Scrollback consistency**: "scroll back" → "scrollback" (line 44)
2. **Tense consistency**: "whether I can" → "whether I could" (line 50)
3. **Capitalization**: "As an Example" → "As an example" (line 76)
4. **Grammar fix**: "We every year, we had" → "Every year, we had" (line 80)

These fixes improve readability and maintain consistency throughout the post.