### PR TITLE
Move team photo to introduction section

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -19,8 +19,6 @@ What happens when three developers lock themselves in a room from 11am to 2pm wi
 
 This is the story of how Mario, Armin, and I built VibeTunnel in one marathon session.
 
-![The VibeTunnel team: Peter, Armin and Mario (from left to right)](/assets/img/2025/vibetunnel/team.jpg)
-
 We met up for a hackathon without knowing exactly what we wanted to build, but we knew one thing: we were all completely in love with building stuff with AI. As we talked, we realized we shared the same frustration - we all wanted to check on our AI agents and see how far they'd gotten with their tasks.
 
 ## Motivation
@@ -28,6 +26,8 @@ We met up for a hackathon without knowing exactly what we wanted to build, but w
 The actual use case that drove us? Being able to check on Claude Code from anywhere, get push notifications, and give it new commands when it's done. This first version lets us control Claude Code remotely - imagine being at lunch and checking if your agent finished that refactoring task, then immediately giving it the next assignment.
 
 But here's the thing - we didn't want to constrain VibeTunnel to just Claude Code. It can control anything in your terminal. The broader frustration remains: accessing your development machine's terminal from anywhere shouldn't require complex SSH setups, port forwarding gymnastics, or fighting with corporate firewalls. We wanted something that just works. And we're making it [open source](https://github.com/amantus-ai/vibetunnel) so everyone can benefit.
+
+![The VibeTunnel team: Peter, Armin and Mario (from left to right)](/assets/img/2025/vibetunnel/team.jpg)
 
 ## The Birth of VibeTunnel
 

--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -19,6 +19,8 @@ What happens when three developers lock themselves in a room from 11am to 2pm wi
 
 This is the story of how Mario, Armin, and I built VibeTunnel in one marathon session.
 
+![The VibeTunnel team: Peter, Armin and Mario (from left to right)](/assets/img/2025/vibetunnel/team.jpg)
+
 We met up for a hackathon without knowing exactly what we wanted to build, but we knew one thing: we were all completely in love with building stuff with AI. As we talked, we realized we shared the same frustration - we all wanted to check on our AI agents and see how far they'd gotten with their tasks.
 
 ## Motivation
@@ -131,8 +133,6 @@ Armin explained why this is actually harder than SSH:
 - **Node.js/Rust/Swift** - Pick your flavor based on your team's expertise or deployment constraints. They all expose the same REST API, so switching between them is literally just changing a command-line flag.
 
 ## The Real MVP: Teamwork, Claude, and Caffeine
-
-![The VibeTunnel team: Peter, Armin and Mario (from left to right)](/assets/img/2025/vibetunnel/team.jpg)
 
 This project happened because of a perfect storm of factors:
 


### PR DESCRIPTION
## Summary
Moved the team photo from the end of the article to right after the introduction for better narrative flow.

## Why This Change?
- **Immediate connection**: Readers see the team when they're first mentioned
- **Personal touch**: Makes the story more human from the start
- **Better engagement**: Helps readers connect faces to names before technical details
- **Sets the tone**: Establishes the "three friends hacking together" vibe early

## Change Details
- Moved photo from "The Real MVP: Teamwork, Claude, and Caffeine" section (line 135)
- Placed after "This is the story of how Mario, Armin, and I built VibeTunnel in one marathon session." (line 22)
- No content changes, just repositioning for better storytelling