### PR TITLE
Remove Xterm.js issue link

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -59,7 +59,7 @@ Mario exclaimed when we finally integrated Xterm.js:
 
 The only issue? Unicode rendering for things like box-drawing characters. When you start Claude Code, you get that nice orange border made of Unicode box-drawing characters - it currently falls back to ASCII replacements like '+' and '-' instead of smooth lines.
 
-> It just looks a little janky, but it's readable. This is a [known Xterm.js issue](https://github.com/xtermjs/xterm.js/issues/3731) with certain font configurations. After fighting with terminal emulation for hours, seeing anything render correctly felt like a victory.
+> It just looks a little janky, but it's readable. After fighting with terminal emulation for hours, seeing anything render correctly felt like a victory.
 
 ### The Streaming Challenge: Six Terminals and You're Out
 


### PR DESCRIPTION
## Summary
Removed the link to the Xterm.js Unicode rendering issue.

## Change
- Removed `[known Xterm.js issue](https://github.com/xtermjs/xterm.js/issues/3731)` reference from line 62
- Kept the description of the Unicode rendering behavior

The text now simply states the rendering issue without linking to the specific GitHub issue.