### PR TITLE
Remove redundant praise section from team descriptions

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
+++ b/src/content/blog/2025/vibetunnel-turn-any-browser-into-your-mac-terminal.md
@@ -134,9 +134,7 @@ Armin explained why this is actually harder than SSH:
 
 This project happened because of a perfect storm of factors:
 
-**Armin's systems wizardry** - He cranked out the Rust binary in 2-3 hours, building the critical process management layer that makes everything possible. Mario praised his work:
-
-> He was done with his little TTY forwarder within about two or three hours. But the best part was his running commentary. While implementing PTY allocation and signal handling - notoriously tricky systems programming - he was simultaneously venting about Xcode as he tried to help with Swift integration. The frustration was so intense that he rage-coded an entire Swift server just to prove a point. It ended up being one of our cleanest implementations.
+**Armin's systems wizardry** - He cranked out the Rust binary in 2-3 hours, building the critical process management layer that makes everything possible.
 
 **Mario's frontend adventures with Claude** - Mario rebuilt the UI layer three times. The first version was a mess (don't judge, it was 11 PM). The second used vanilla JavaScript and quickly became unmaintainable. The third, using Lit, was the charm. Claude was his constant companion, generating boilerplate, explaining APIs, and occasionally leading him astray with over-engineered solutions. The key was learning when to trust Claude and when to take control.
 


### PR DESCRIPTION
## Summary
Removed the quoted section about Armin's TTY forwarder work and Xcode frustrations.

## Changes
- Removed Mario's praise quote and the detailed description of Armin's work
- Kept the concise description: "He cranked out the Rust binary in 2-3 hours"
- Makes the team member descriptions more balanced in length

This keeps the team section focused and avoids redundancy since Xcode frustrations are already mentioned elsewhere in the article.