### PR TITLE
Add window ordering code to Settings menu bar blog post

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework


### PR DESCRIPTION
## Summary
- Added window ordering logic to ensure settings window properly comes to front
- Added `findSettingsWindow()` helper function with multiple detection methods
- Improved reliability of settings window presentation from menu bar apps

## Changes
- Added window ordering code after `openSettings()` call with 200ms delay
- Implemented `findSettingsWindow()` function that tries multiple methods to locate the settings window:
  - By window identifier (`com.apple.SwiftUI.Settings`)
  - By window title (checking for "settings" or "preferences")
  - By content view controller type
- Added calls to `makeKeyAndOrderFront()` and `orderFrontRegardless()` to ensure window comes to front

## Test plan
- [x] Build succeeds with `npm run build`
- [x] No formatting or linting errors
- [x] Blog post renders correctly with new code sample