### PR TITLE
Fix GitHub anchor link in stats.store blog post

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/src/content/blog/2025/stats-store-privacy-first-sparkle-analytics.md
+++ b/src/content/blog/2025/stats-store-privacy-first-sparkle-analytics.md
@@ -47,7 +47,7 @@ Everything is designed to answer simple questions: How many people use my app? W
 
 Here's the deal: if you're building open source Mac apps, it's completely free. I'll cover the hosting (Vercel and Supabase make this pretty cheap anyway).
 
-Want in? Just [email me](mailto:peter@steipete.me). I'll add your app to the backend - and by backend, I mean I'll literally go into Supabase and edit the table. We're keeping it scrappy. All you have to do is [redirecting the appcast URLs](https://github.com/steipete/stats-store#sparkle-integration), stats.store will fetch the correct one and pass them along.
+Want in? Just [email me](mailto:peter@steipete.me). I'll add your app to the backend - and by backend, I mean I'll literally go into Supabase and edit the table. We're keeping it scrappy. All you have to do is [redirect the appcast URLs](https://github.com/steipete/stats-store#how-it-works-the-magic-part-), stats.store will fetch the correct one and pass them along.
 
 If enough people join, we'll have a nice community dataset showing how fast Mac users update their OS and what hardware they're running. Could be interesting!
 


### PR DESCRIPTION
Fixes the broken anchor link that was pointing to #sparkle-integration (which doesn't exist) to point to the correct #how-it-works-the-magic-part- section in the stats-store README. Also fixed the grammar from 'redirecting' to 'redirect'.