### PR TITLE
Add stats.store link in tl;dr section

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,6 +109,18 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
+## Slash Commands
+
+### /merged Command
+
+When the user types `/merged`, perform the following actions:
+
+1. Switch to the main branch: `git checkout main`
+2. Pull and rebase the latest changes: `git pull --rebase origin main`
+3. Confirm completion with a brief message
+
+This workflow ensures the main branch is always up-to-date after merging a PR.
+
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -109,18 +109,6 @@ npm run preview
    - If a build fails after updates, diagnose the specific issue and FIX it properly
    - NEVER resort to downgrading as a solution
 
-## Slash Commands
-
-### /merged Command
-
-When the user types `/merged`, perform the following actions:
-
-1. Switch to the main branch: `git checkout main`
-2. Pull and rebase the latest changes: `git pull --rebase origin main`
-3. Confirm completion with a brief message
-
-This workflow ensures the main branch is always up-to-date after merging a PR.
-
 ## Tech Stack
 
 - **Astro** (latest version) - Main framework

--- a/src/content/blog/2025/stats-store-privacy-first-sparkle-analytics.md
+++ b/src/content/blog/2025/stats-store-privacy-first-sparkle-analytics.md
@@ -13,7 +13,7 @@ tags:
 draft: false
 ---
 
-**tl;dr**: I built a free, open source analytics backend for Sparkle because all existing solutions are ancient, and I wanted to know how many people use [VibeTunnel](https://vibetunnel.sh) without being creepy about it.
+**tl;dr**: I built a [free, open source analytics backend](https://stats.store) for Sparkle because all existing solutions are ancient, and I wanted to know how many people use [VibeTunnel](https://vibetunnel.sh) without being creepy about it.
 
 I'm philosophically against deep app analytics. Everything I make is open source and free, and integrating an analytics SDK just didn't feel right. Sparkle has this neat little [system profiling](https://sparkle-project.org/documentation/system-profiling/) feature that's perfect for people like me - it just tells you the macOS version and how many people opened your app this week. No IP addresses, no creepy tracking, just enough to stay motivated.
 

--- a/src/content/blog/2025/stats-store-privacy-first-sparkle-analytics.md
+++ b/src/content/blog/2025/stats-store-privacy-first-sparkle-analytics.md
@@ -15,7 +15,7 @@ draft: false
 
 **tl;dr**: I built a [free, open source analytics backend](https://stats.store) for Sparkle because all existing solutions are ancient, and I wanted to know how many people use [VibeTunnel](https://vibetunnel.sh) without being creepy about it.
 
-I'm philosophically against deep app analytics. Everything I make is open source and free, and integrating an analytics SDK just didn't feel right. Sparkle has this neat little [system profiling](https://sparkle-project.org/documentation/system-profiling/) feature that's perfect for people like me - it just tells you the macOS version and how many people opened your app this week. No IP addresses, no creepy tracking, just enough to stay motivated.
+I'm philosophically against deep app analytics. Everything I make is open source and free, and integrating an analytics SDK just didn't feel right. Sparkle has this neat little [system profiling](https://sparkle-project.org/documentation/system-profiling/) feature that's perfect for people like me - it just tells you the macOS version and how many people opened your app this week. No IP addresses, no invasive tracking, just enough to stay motivated.
 
 The problem? When I checked for backend implementations, [everything was ancient](https://sparkle-project.org/documentation/system-profiling/). So naturally, I thought: "How hard can it be?"
 


### PR DESCRIPTION
Links 'free, open source analytics backend' to https://stats.store in the tl;dr section of the stats.store blog post.