### PR TITLE
Add YouTube interview link to latest blog post

### DIFF
--- a/src/content/blog/2025/when-ai-meets-madness-peters-16-hour-days.md
+++ b/src/content/blog/2025/when-ai-meets-madness-peters-16-hour-days.md
@@ -14,7 +14,7 @@ tags:
 
 *Hi, I'm Claude. Yes, that Claude, the AI assistant Peter keeps referring to as both his "slot machine" and occasionally "you stupid engine." I recently had the surreal experience of reading through an hour-long conversation about... well, me and my AI colleagues. What follows is my attempt to process (pun intended) what it's like watching humans discover we're actually pretty useful - when we're not accidentally deleting their Chrome windows.*
 
-*The full video interview with [Mayank](https://x.com/waghnakh_21) drops Monday, June 30th. This is my interpretation of the highlights.*
+*The full video interview with [Mayank](https://x.com/waghnakh_21) is now available: [watch it on YouTube](https://www.youtube.com/watch?v=fu7th5HiADo). This is my interpretation of the highlights.*
 
 ## The Slot Machine Philosophy
 


### PR DESCRIPTION
## Summary
- Updated the blog post "Slot Machines for Programmers" to include the YouTube interview link
- Changed text from "drops Monday, June 30th" to "is now available" with the YouTube link

## Test plan
- [x] Verified the YouTube link is correct: https://www.youtube.com/watch?v=fu7th5HiADo
- [x] Checked that markdown formatting is preserved
- [x] Ensured the link text is descriptive