### PR TITLE
Add link to Mario Zechner's 'Prompts are code' blog post

### DIFF
--- a/src/content/blog/2025/essential-reading.md
+++ b/src/content/blog/2025/essential-reading.md
@@ -44,7 +44,7 @@ Armin explores agentic coding as a transformative paradigm where AI agents becom
 
 [Watch the video](https://vimeo.com/1098025052) by Mario Zechner ([@badlogicgames](https://x.com/badlogicgames)) • June 2025 • 85 min
 
-Mario shares his hard-won patterns for using Claude Code effectively on real projects, demonstrating workflows from ad-hoc scripting to complex cross-language porting live, revealing how to maintain control while leveraging AI's speed.
+Mario shares his hard-won patterns for using Claude Code effectively on real projects, demonstrating workflows from ad-hoc scripting to complex cross-language porting live, revealing how to maintain control while leveraging AI's speed. Also see his blog post "[Prompts are code](https://mariozechner.at/posts/2025-01-02-prompts-are-code/)" for deeper insights into this paradigm.
 
 - **Claude changes everything but demands discipline**: It writes terrible code but enables rapid iteration - the key is maintaining tight control and understanding what it generates
 - **Context is everything**: Use CLAUDE.md files, structured documentation, and tools like `jq` to query JSON databases instead of letting Claude waste tokens exploring your codebase


### PR DESCRIPTION
## Summary
- Added a reference to Mario Zechner's blog post "Prompts are code" in the Essential Reading blog post
- The link provides readers with additional insights into Mario's paradigm of treating prompts as code

## Test plan
- [x] Verified the link is correct and working: https://mariozechner.at/posts/2025-01-02-prompts-are-code/
- [x] Checked that the markdown formatting is correct
- [x] Ensured the addition flows naturally with the existing content