### PR TITLE
Add blog post about logging privacy shenanigans

### DIFF
--- a/src/content/blog/2025/logging-privacy-shenanigans.md
+++ b/src/content/blog/2025/logging-privacy-shenanigans.md
@@ -1,0 +1,182 @@
+---
+title: "Logging Privacy Shenanigans"
+pubDatetime: 2025-07-29T16:00:00.000+02:00
+description: "How Apple's log privacy redaction works and how to temporarily disable it for debugging"
+tags:
+  - macOS
+  - Logging
+  - Privacy
+  - Debugging
+  - Swift
+  - Developer Tools
+---
+
+If you've ever tried debugging a macOS app using the unified logging system, you've probably encountered the dreaded `<private>` redaction. Your carefully crafted log messages turn into cryptic puzzles where the most important debugging information is hidden. Let me show you what's really going on and how to work around it.
+
+## The Privacy Problem
+
+When you log something like this in Swift:
+
+```swift
+logger.info("User \(username) connected to session \(sessionId)")
+```
+
+You expect to see:
+```
+User john.doe connected to session ABC-123-DEF
+```
+
+But instead you get:
+```
+User <private> connected to session <private>
+```
+
+Not very helpful when you're trying to debug an issue, right?
+
+## What Actually Gets Redacted
+
+Here's where it gets interesting. Through testing, I discovered that Apple's redaction logic is **not** as straightforward as the documentation suggests:
+
+| What you log | Documentation says | Reality |
+|--------------|-------------------|---------|
+| Simple strings (`"user@example.com"`) | Redacted | **Not redacted!** |
+| File paths (`/Users/username`) | Redacted | ✓ Redacted |
+| UUIDs (`ABC-123-DEF`) | Redacted | ✓ Redacted |
+| Integers, booleans, floats | Public | ✓ Public |
+
+The discrepancy likely comes from hardcoded strings versus dynamically generated values. Apple's privacy system appears to use pattern matching to decide what to redact.
+
+## Old Solutions That No Longer Work
+
+Before we get to what works, let's quickly cover what **doesn't** work anymore:
+
+### ❌ The `private_data:on` flag (Dead since Catalina)
+
+```bash
+# This returns "Invalid Modes 'private_data:on'" on macOS 10.15+
+sudo log config --mode "private_data:on" --subsystem your.app.subsystem
+```
+
+This was completely removed in macOS Catalina (10.15) and later.
+
+### ❌ sudo doesn't reveal private data
+
+You might think running with sudo would show everything:
+
+```bash
+sudo log show --predicate 'subsystem == "your.app"' --info
+```
+
+Nope! The privacy redaction happens at **write time**, not read time. Once logged as `<private>`, the actual data is gone forever.
+
+## The Configuration Profile Solution
+
+The only reliable way to see private data is to tell macOS to capture it in the first place using a configuration profile. Here's how:
+
+### Step 1: Create the Profile
+
+Save this as `EnablePrivateLogging.mobileconfig`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>PayloadContent</key>
+    <array>
+        <dict>
+            <key>PayloadDisplayName</key>
+            <string>ManagedClient logging</string>
+            <key>PayloadEnabled</key>
+            <true/>
+            <key>PayloadIdentifier</key>
+            <string>com.example.logging.EnablePrivateData</string>
+            <key>PayloadType</key>
+            <string>com.apple.system.logging</string>
+            <key>PayloadUUID</key>
+            <string>YOUR-UUID-HERE</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>System</key>
+            <dict>
+                <key>Enable-Private-Data</key>
+                <true/>
+            </dict>
+            <key>Subsystems</key>
+            <dict>
+                <key>your.app.subsystem</key>
+                <dict>
+                    <key>DEFAULT-OPTIONS</key>
+                    <dict>
+                        <key>Enable-Private-Data</key>
+                        <true/>
+                    </dict>
+                </dict>
+            </dict>
+        </dict>
+    </array>
+    <key>PayloadDescription</key>
+    <string>Enable private data logging for debugging</string>
+    <key>PayloadDisplayName</key>
+    <string>Private Data Logging</string>
+    <key>PayloadIdentifier</key>
+    <string>com.example.PrivateDataLogging</string>
+    <key>PayloadRemovalDisallowed</key>
+    <false/>
+    <key>PayloadType</key>
+    <string>Configuration</string>
+    <key>PayloadUUID</key>
+    <string>ANOTHER-UUID-HERE</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+</dict>
+</plist>
+```
+
+### Step 2: Install the Profile
+
+1. Double-click the `.mobileconfig` file
+2. Navigate to:
+   - **macOS 15 (Sequoia) and later**: System Settings → General → Device Management
+   - **macOS 14 (Sonoma) and earlier**: System Settings → Privacy & Security → Profiles
+3. Click "Install..." and authenticate
+4. Wait 1-2 minutes for the system to apply changes
+
+### Step 3: Generate Fresh Logs
+
+The profile only affects **new** log entries. Existing `<private>` entries remain redacted forever.
+
+### Step 4: Remove When Done
+
+⚠️ **CRITICAL**: This profile disables ALL privacy protection for your logs. Passwords, tokens, and sensitive data will be logged in plain text. Always remove the profile after debugging!
+
+## The Code-Level Solution
+
+For production apps, mark specific non-sensitive values as public:
+
+```swift
+// This will always be visible
+logger.info("Session: \(sessionId, privacy: .public)")
+
+// This remains private by default
+logger.info("Token: \(apiToken)")
+```
+
+This is the safest approach as you explicitly control what's exposed.
+
+## macOS 26 and Beyond
+
+Yes, you read that right in the installation instructions - Apple moved the Profiles settings **again**. It's now under General → Device Management in Sequoia, making it easier to find alongside other enterprise management features.
+
+## Summary
+
+Apple's log privacy is well-intentioned but can be frustrating during development. The configuration profile approach is your best bet for debugging, but remember:
+
+1. Privacy redaction happens at write time
+2. sudo can't recover what was never stored
+3. Simple strings might not be redacted (but don't rely on this)
+4. Always remove debugging profiles when done
+
+For more details on this topic, check out Howard Oakley's excellent post: [Removing privacy censorship from the log](https://eclecticlight.co/2023/03/08/removing-privacy-censorship-from-the-log/).
+
+Happy debugging, and may your logs be forever unredacted (but only when you need them to be)!


### PR DESCRIPTION
## Summary
- Added new blog post explaining Apple's log privacy redaction system
- Covers how to temporarily disable privacy redaction for debugging using configuration profiles
- Includes practical examples and warnings about security implications

## Test plan
- [ ] Preview the blog post in the local development server
- [ ] Verify all code examples are properly formatted
- [ ] Check that links work correctly
- [ ] Ensure the post appears in the blog index

🤖 Generated with [Claude Code](https://claude.ai/code)