### PR TITLE
Fix broken Essential Reading cross-links

### DIFF
--- a/src/content/blog/2025/essential-reading-july-2025.md
+++ b/src/content/blog/2025/essential-reading-july-2025.md
@@ -69,4 +69,4 @@ Manuel presents a provocative technical argument that MCPs artificially limit LL
 
 ---
 
-*This builds on my [original Essential Reading collection](/posts/essential-reading) with fresh insights from the field.*
+*This builds on my [original Essential Reading collection](/posts/2025/essential-reading) with fresh insights from the field.*

--- a/src/content/blog/2025/essential-reading.md
+++ b/src/content/blog/2025/essential-reading.md
@@ -112,4 +112,4 @@ Andrej presents a framework for understanding software evolution through three p
 
 ---
 
-**Continue Reading**: Check out [Essential Reading for Agentic Engineers - July 2025](/posts/essential-reading-july-2025) for fresh perspectives from the field, including real-world productivity reports and technical deep-dives into the evolving landscape of AI-assisted development.
+**Continue Reading**: Check out [Essential Reading for Agentic Engineers - July 2025](/posts/2025/essential-reading-july-2025) for fresh perspectives from the field, including real-world productivity reports and technical deep-dives into the evolving landscape of AI-assisted development.


### PR DESCRIPTION
## Summary
- Fix link in July 2025 post: `/posts/essential-reading` → `/posts/2025/essential-reading`  
- Fix link in original post: `/posts/essential-reading-july-2025` → `/posts/2025/essential-reading-july-2025`
- Both links now use correct URL structure with `/posts/2025/` prefix

## Test plan
- [x] Verified fix by running `npm run build` successfully
- [x] Both Essential Reading posts now generate correct URLs
- [x] Cross-links between posts work properly