### PR TITLE
Remove month references from Essential Reading posts

### DIFF
--- a/src/content/blog/2025/essential-reading-august-2025.md
+++ b/src/content/blog/2025/essential-reading-august-2025.md
@@ -9,13 +9,13 @@ tags: ["ai", "claude", "development", "claude-code", "best-practices", "agentic-
 
 **The reinvention of software development is happening now.** 
 
-This August edition cuts through the AI hype with five essential perspectives that reveal both the promise and peril of our evolving profession. We track developers' evolution from AI skeptics to strategists, examine how juniors are losing fundamental skills, reality-check the 10x productivity myths, and explore why both platform monopolies and MCP server proliferation may be dead ends.
+This edition cuts through the AI hype with five essential perspectives that reveal both the promise and peril of our evolving profession. We track developers' evolution from AI skeptics to strategists, examine how juniors are losing fundamental skills, reality-check the 10x productivity myths, and explore why both platform monopolies and MCP server proliferation may be dead ends.
 
 🤖 *Heads Up: [Summaries are AI-Assisted](/posts/2025/startup-slop). All posts are hand-picked.*
 
 ## Developers, Reinvented
 
-[Read the article](https://ashtom.github.io/developers-reinvented) by Thomas Dohmke ([@ashtom](https://x.com/ashtom)) • August 2025 • 11 min
+[Read the article](https://ashtom.github.io/developers-reinvented) by Thomas Dohmke ([@ashtom](https://x.com/ashtom)) • 11 min
 
 Thomas presents groundbreaking research from interviews with developers who've made AI tools central to their workflows, revealing a four-stage evolution that's reshaping software development from skepticism to strategic AI orchestration.
 
@@ -31,7 +31,7 @@ The research reveals "realistic optimists" who acknowledge disruption while embr
 
 ## The Hidden Cost of AI-Assisted Learning
 
-[Read the article](https://nmn.gl/blog/ai-and-learning) by Nemil Dalal ([@nemild](https://x.com/nemild)) • August 2025 • 8 min
+[Read the article](https://nmn.gl/blog/ai-and-learning) by Nemil Dalal ([@nemild](https://x.com/nemild)) • 8 min
 
 Nemil presents a sobering counterpoint to AI evangelism, examining how AI tools may be creating a generation of developers who can ship code without truly understanding it—trading deep knowledge for quick fixes.
 
@@ -47,7 +47,7 @@ This critical perspective complements the optimistic evolution narrative, highli
 
 ## Reality Check: AI's Actual Impact on Productivity
 
-[Read the article](https://colton.dev/blog/curing-your-ai-10x-engineer-imposter-syndrome/) by Colton Anglin • August 2025 • 6 min
+[Read the article](https://colton.dev/blog/curing-your-ai-10x-engineer-imposter-syndrome/) by Colton Anglin • 6 min
 
 Colton delivers a much-needed reality check on the hyperbolic claims of 10x or 100x productivity gains from AI, offering reassurance to engineers experiencing imposter syndrome in the face of aggressive AI marketing.
 
@@ -63,7 +63,7 @@ This grounded perspective serves as an antidote to both AI evangelism and doom-s
 
 ## The End of Platform Dominance
 
-[Read the article](https://www.aparker.io/post/3lvjepuyf4q2w) by Austin Parker ([@aparker.io](https://bsky.app/profile/aparker.io)) • August 2025 • 10 min
+[Read the article](https://www.aparker.io/post/3lvjepuyf4q2w) by Austin Parker ([@aparker.io](https://bsky.app/profile/aparker.io)) • 10 min
 
 Austin presents a visionary thesis on how AI will fundamentally restructure the software industry, shifting from today's platform monopolies to tomorrow's ecosystem of small, custom applications built on open protocols.
 
@@ -79,7 +79,7 @@ This radical vision complements our exploration of role transformation by imagin
 
 ## Less is More: The Hidden Costs of MCP Server Proliferation
 
-[Read the article](https://ghuntley.com/allocations/) by Geoffrey Huntley ([@geoff](https://x.com/GeoffreyHuntley)) • August 2025 • 10 min
+[Read the article](https://ghuntley.com/allocations/) by Geoffrey Huntley ([@geoff](https://x.com/GeoffreyHuntley)) • 10 min
 
 Geoffrey presents a critical analysis of Model Context Protocol (MCP) servers, warning that the rush to add more tools and integrations is actually degrading AI coding assistant performance rather than improving it.
 

--- a/src/content/blog/2025/essential-reading-july-2025.md
+++ b/src/content/blog/2025/essential-reading-july-2025.md
@@ -9,11 +9,11 @@ tags: ["ai", "claude", "development", "claude-code", "best-practices", "agentic-
 
 **New perspectives on AI-assisted development from the field.** 
 
-This July edition features four compelling articles that showcase the evolving landscape of agentic engineering: a detailed experience report from a team successfully integrating Claude Code into production workflows, a thought-provoking analysis of how AI tools are reshaping developer career paths, a candid look at AI automation experiments that didn't work as expected, and a technical deep-dive challenging conventional wisdom about MCP limitations.
+This edition features four compelling articles that showcase the evolving landscape of agentic engineering: a detailed experience report from a team successfully integrating Claude Code into production workflows, a thought-provoking analysis of how AI tools are reshaping developer career paths, a candid look at AI automation experiments that didn't work as expected, and a technical deep-dive challenging conventional wisdom about MCP limitations.
 
 ## Six Weeks of Claude Code
 
-[Read the article](https://blog.puzzmo.com/posts/2025/07/30/six-weeks-of-claude-code/) by Orta Therox ([@orta](https://x.com/orta)) • July 2025 • 12 min
+[Read the article](https://blog.puzzmo.com/posts/2025/07/30/six-weeks-of-claude-code/) by Orta Therox ([@orta](https://x.com/orta)) • 12 min
 
 Orta shares his experience integrating Claude Code into daily development work at Puzzmo, providing one of the most detailed real-world productivity assessments available. His team completed 15+ significant engineering tasks in just six weeks, demonstrating measurable impact on technical debt resolution and feature development.
 
@@ -27,7 +27,7 @@ Orta shares his experience integrating Claude Code into daily development work a
 
 ## Full-Breadth Developers
 
-[Read the article](https://justin.searls.co/posts/full-breadth-developers/) by Justin Searls ([@searls](https://x.com/searls)) • July 2025 • 15 min
+[Read the article](https://justin.searls.co/posts/full-breadth-developers/) by Justin Searls ([@searls](https://x.com/searls)) • 15 min
 
 Justin explores how AI tools are enabling a new archetype of "full-breadth developers" who can work effectively across the entire technology stack, fundamentally challenging traditional specialization models and career development paths.
 
@@ -41,7 +41,7 @@ Justin explores how AI tools are enabling a new archetype of "full-breadth devel
 
 ## Things That Didn't Work
 
-[Read the article](https://lucumr.pocoo.org/2025/7/30/things-that-didnt-work/) by Armin Ronacher ([@mitsuhiko](https://x.com/mitsuhiko)) • July 2025 • 18 min
+[Read the article](https://lucumr.pocoo.org/2025/7/30/things-that-didnt-work/) by Armin Ronacher ([@mitsuhiko](https://x.com/mitsuhiko)) • 18 min
 
 Armin provides a candid retrospective on AI coding experiments that failed, offering valuable lessons for developers navigating the AI-assisted development landscape. His honest analysis of what didn't work provides essential balance to the enthusiasm around AI automation.
 
@@ -55,7 +55,7 @@ Armin provides a candid retrospective on AI coding experiments that failed, offe
 
 ## MCPs are Boring (or: Why we are losing the Sparkle of LLMs)
 
-[Watch the video](https://www.youtube.com/watch?v=J3oJqan2Gv8) by Manuel Odendahl ([@programwithai](https://x.com/programwithai)) • July 2025 • 32 min
+[Watch the video](https://www.youtube.com/watch?v=J3oJqan2Gv8) by Manuel Odendahl ([@programwithai](https://x.com/programwithai)) • 32 min
 
 Manuel presents a provocative technical argument that MCPs artificially limit LLM capabilities by forcing structured tool calls instead of leveraging their superior code generation abilities. His presentation challenges the entire foundation of current agentic development practices with concrete performance data and working implementations.
 
@@ -69,7 +69,7 @@ Manuel presents a provocative technical argument that MCPs artificially limit LL
 
 ## Coding with LLMs in Summer 2025
 
-[Read the article](https://antirez.com/news/154) by Salvatore Sanfilippo ([@antirez](https://x.com/antirez)) • July 2025 • 8 min
+[Read the article](https://antirez.com/news/154) by Salvatore Sanfilippo ([@antirez](https://x.com/antirez)) • 8 min
 
 Antirez (creator of Redis) shares practical insights from using LLMs for coding, emphasizing the critical importance of keeping humans "in the loop" while leveraging AI's transformative capabilities for software development.
 


### PR DESCRIPTION
## Summary
- Remove redundant month references from Essential Reading posts
- Makes the content more timeless and less date-specific
- Improves consistency across the Essential Reading series

## Changes
- Updated July 2025 Essential Reading: Removed "July" from introduction and all article metadata lines
- Updated August 2025 Essential Reading: Removed "August" from introduction and all article metadata lines
- Kept publication months in titles as they serve as unique identifiers for each collection

## Why This Change?
The month references in the article descriptions were redundant since:
1. The month is already in the post title
2. The publication date is in the metadata
3. Removing them makes the content feel more evergreen while still being clearly dated through the title