### PR TITLE
Add OpenAI GPT-5 Prompting Guide link to Live Coding Session post

### DIFF
--- a/src/content/blog/2025/live-coding-session-building-arena.md
+++ b/src/content/blog/2025/live-coding-session-building-arena.md
@@ -62,3 +62,5 @@ I managed to complete the feature in ~1h, and we got a  **pair score of 89** for
 * **Compaction & long sessions?** Plan features to **fit the context**. If you expect many loops (e.g., test repairs), use the flow that compacts well - or split the task.
 
 If you want to read more about my agent workflow, check [my AI development post here](/posts/2025/optimal-ai-development-workflow).
+
+For more advanced prompting techniques with GPT-5, also check out the [OpenAI GPT-5 Prompting Guide](https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide).


### PR DESCRIPTION
## Summary
- Add reference to OpenAI's GPT-5 Prompting Guide from their cookbook
- Complements the existing AI workflow resources in the Live Coding Session post
- Provides readers with advanced prompting techniques for GPT-5

## Changes
- Added link to https://cookbook.openai.com/examples/gpt-5/gpt-5_prompting_guide
- Placed at the end with other related reading recommendations
- Flows naturally after the existing workflow post reference

## Test Plan
- [x] Link added to appropriate section of the blog post
- [x] Content flows naturally with existing resources
- [x] URL is correct and accessible