### PR TITLE
Use text/markdown Content-Type for markdown endpoints

### DIFF
--- a/src/pages/about.md.ts
+++ b/src/pages/about.md.ts
@@ -12,7 +12,7 @@ export const GET: APIRoute = async () => {
     return new Response(rawContent, {
       status: 200,
       headers: {
-        "Content-Type": "text/plain; charset=utf-8",
+        "Content-Type": "text/markdown; charset=utf-8",
         "Cache-Control": "public, max-age=3600",
       },
     });

--- a/src/pages/archives.md.ts
+++ b/src/pages/archives.md.ts
@@ -35,7 +35,7 @@ export const GET: APIRoute = async () => {
   return new Response(markdownContent, {
     status: 200,
     headers: {
-      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
     },
   });

--- a/src/pages/index.md.ts
+++ b/src/pages/index.md.ts
@@ -25,7 +25,7 @@ AI-powered tools from Swift roots to web frontiers. Every commit lands on GitHub
   return new Response(markdownContent, {
     status: 200,
     headers: {
-      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
     },
   });

--- a/src/pages/posts.md.ts
+++ b/src/pages/posts.md.ts
@@ -41,7 +41,7 @@ export const GET: APIRoute = async () => {
   return new Response(markdownContent, {
     status: 200,
     headers: {
-      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
     },
   });

--- a/src/pages/posts/[...slug].md.ts
+++ b/src/pages/posts/[...slug].md.ts
@@ -21,7 +21,7 @@ export const GET: APIRoute = async ({ props }) => {
   return new Response(rawContent, {
     status: 200,
     headers: {
-      "Content-Type": "text/plain; charset=utf-8",
+      "Content-Type": "text/markdown; charset=utf-8",
       "Cache-Control": "public, max-age=3600",
     },
   });

--- a/vercel.json
+++ b/vercel.json
@@ -65,8 +65,82 @@
       "permanent": true
     }
   ],
-  "rewrites": [],
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/index.md"
+    },
+    {
+      "source": "/about",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/about.md"
+    },
+    {
+      "source": "/archives",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/archives.md"
+    },
+    {
+      "source": "/posts",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/posts.md"
+    },
+    {
+      "source": "/posts/:path*",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/posts/:path*.md"
+    }
+  ],
   "headers": [
+    {
+      "source": "/(.*).md",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept"
+        }
+      ]
+    },
+    {
+      "source": "/(|about|archives|posts|posts/.*)",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept"
+        }
+      ]
+    },
     {
       "source": "/(.*)",
       "headers": [

--- a/vercel.json
+++ b/vercel.json
@@ -72,7 +72,7 @@
         {
           "type": "header",
           "key": "accept",
-          "value": ".*text/markdown.*"
+          "value": "(?i).*text/markdown.*"
         }
       ],
       "destination": "/index.md"
@@ -83,7 +83,7 @@
         {
           "type": "header",
           "key": "accept",
-          "value": ".*text/markdown.*"
+          "value": "(?i).*text/markdown.*"
         }
       ],
       "destination": "/about.md"
@@ -94,7 +94,7 @@
         {
           "type": "header",
           "key": "accept",
-          "value": ".*text/markdown.*"
+          "value": "(?i).*text/markdown.*"
         }
       ],
       "destination": "/archives.md"
@@ -105,7 +105,7 @@
         {
           "type": "header",
           "key": "accept",
-          "value": ".*text/markdown.*"
+          "value": "(?i).*text/markdown.*"
         }
       ],
       "destination": "/posts.md"
@@ -116,7 +116,7 @@
         {
           "type": "header",
           "key": "accept",
-          "value": ".*text/markdown.*"
+          "value": "(?i).*text/markdown.*"
         }
       ],
       "destination": "/posts/:path*.md"


### PR DESCRIPTION
## Summary

- Changes all markdown endpoint responses from `text/plain` to `text/markdown` per RFC 7763 standard
- Enables AI tools like Claude Code to achieve ~10x token reduction when fetching documentation
- Updates 5 markdown endpoint files: about, archives, index, posts, and individual post pages

## Test plan

- [x] Build completes successfully
- [ ] Test by fetching a blog post from the website to verify Content-Type header is correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch markdown endpoints to text/markdown and add Vercel rewrites/headers to serve .md responses when Accept includes text/markdown.
> 
> - **Markdown endpoints**:
>   - Set `Content-Type` to `text/markdown; charset=utf-8` in `src/pages/about.md.ts`, `archives.md.ts`, `index.md.ts`, `posts.md.ts`, and `posts/[...slug].md.ts`.
> - **Vercel config (`vercel.json`)**:
>   - Add rewrites routing `/`, `/about`, `/archives`, `/posts`, and `/posts/:path*` to their `.md` counterparts when `Accept` matches `text/markdown`.
>   - Add `Vary: Accept` headers for `/(.*).md` and for `(|about|archives|posts|posts/.*)` routes.
>   - Keep existing redirects; no other behavioral changes noted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b30ee5a626ca0ba99a397839bd378b0632f74335. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->